### PR TITLE
Add Emma pricing page components

### DIFF
--- a/component-playground/src/stories/emma-faq-section.stories.js
+++ b/component-playground/src/stories/emma-faq-section.stories.js
@@ -1,0 +1,49 @@
+import { fn } from '@storybook/test';
+import EmmaFaqSection from './../../../components/emma-faq-section';
+
+export default {
+    title: 'Emma/FAQ Section',
+    component: EmmaFaqSection,
+    parameters: {
+        layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        faqHeading: { control: 'text' },
+        ctaHeading: { control: 'text' },
+        ctaDescription: { control: 'text' },
+        ctaButtonText: { control: 'text' },
+        ctaButtonLink: { control: 'text' },
+        primaryColor__limio_color: { control: 'color' },
+    },
+};
+
+export const Primary = {
+    args: {
+        faqHeading: 'Frequently Asked Questions',
+        faqItems: [
+            {
+                question: 'Who is eligible for these plans?',
+                answer: '<p>These plans are available for new customers purchasing from July 21, 2022. Existing customers can contact their account manager for migration options.</p>',
+            },
+            {
+                question: 'What if I have more than 10,000 contacts?',
+                answer: '<p>If you have more than 10,000 contacts, please contact us for a custom quote tailored to your needs. We offer flexible pricing for larger contact lists.</p>',
+            },
+            {
+                question: 'Can I change plans later?',
+                answer: '<p>Yes, you can upgrade or downgrade your plan at any time. Changes take effect at the start of your next billing cycle.</p>',
+            },
+            {
+                question: 'Is there a free trial available?',
+                answer: '<p>We offer personalized demos so you can see exactly how Emma works for your business. Request a demo to get started.</p>',
+            },
+        ],
+        ctaHeading: 'Get expert help when you need it',
+        ctaDescription: 'Our Professional Services team can help you build long-term brand loyalty, maximize marketing success, and drive optimal business results.',
+        ctaButtonText: "Let's chat",
+        ctaButtonLink: '/contact',
+        primaryColor__limio_color: '#053A5E',
+        componentId: 'emma-faq-section',
+    }
+};

--- a/component-playground/src/stories/emma-feature-comparison.stories.js
+++ b/component-playground/src/stories/emma-feature-comparison.stories.js
@@ -1,0 +1,21 @@
+import { fn } from '@storybook/test';
+import EmmaFeatureComparison from './../../../components/emma-feature-comparison';
+
+export default {
+    title: 'Emma/Feature Comparison',
+    component: EmmaFeatureComparison,
+    parameters: {
+        layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        heading: { control: 'text' },
+    },
+};
+
+export const Primary = {
+    args: {
+        heading: 'Compare plans',
+        componentId: 'emma-feature-comparison',
+    }
+};

--- a/component-playground/src/stories/emma-pricing-cards.stories.js
+++ b/component-playground/src/stories/emma-pricing-cards.stories.js
@@ -1,0 +1,27 @@
+import { fn } from '@storybook/test';
+import EmmaPricingCards from './../../../components/emma-pricing-cards';
+
+export default {
+    title: 'Emma/Pricing Cards',
+    component: EmmaPricingCards,
+    parameters: {
+        layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        heading: { control: 'text' },
+        subheading: { control: 'text' },
+        primaryColor__limio_color: { control: 'color' },
+        ctaColor__limio_color: { control: 'color' },
+    },
+};
+
+export const Primary = {
+    args: {
+        heading: 'Flexible plans for teams of all sizes.',
+        subheading: 'Prices starting at $99/month.',
+        primaryColor__limio_color: '#053A5E',
+        ctaColor__limio_color: '#053A5E',
+        componentId: 'emma-pricing-cards',
+    }
+};

--- a/component-playground/src/stories/emma-pricing-hero.stories.js
+++ b/component-playground/src/stories/emma-pricing-hero.stories.js
@@ -1,0 +1,23 @@
+import { fn } from '@storybook/test';
+import EmmaPricingHero from './../../../components/emma-pricing-hero';
+
+export default {
+    title: 'Emma/Pricing Hero',
+    component: EmmaPricingHero,
+    parameters: {
+        layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        heading: { control: 'text' },
+        subheading: { control: 'text' },
+    },
+};
+
+export const Primary = {
+    args: {
+        heading: 'Flexible plans for teams of all sizes.',
+        subheading: 'Prices starting at $99/month.',
+        componentId: 'emma-pricing-hero',
+    }
+};

--- a/components/emma-faq-section/components/CtaBanner.js
+++ b/components/emma-faq-section/components/CtaBanner.js
@@ -1,0 +1,28 @@
+// @flow
+import React from "react";
+
+const CtaBanner = ({ heading, description, buttonText, buttonLink, primaryColor }) => {
+  return (
+    <div className="mt-16 bg-gray-50 dark:bg-gray-800 rounded-2xl p-8 lg:p-12">
+      <div className="flex flex-col lg:flex-row items-center gap-8">
+        <div className="flex-1 text-center lg:text-left">
+          <h3 className="text-2xl lg:text-3xl font-extrabold text-gray-900 dark:text-white mb-4">
+            {heading}
+          </h3>
+          <p className="text-gray-500 dark:text-gray-400 text-lg leading-relaxed mb-6">
+            {description}
+          </p>
+          <a
+            href={buttonLink}
+            className="inline-flex items-center justify-center rounded-lg px-6 py-3 text-sm font-semibold text-white transition-colors duration-200 focus:ring-4 focus:ring-blue-200"
+            style={{ backgroundColor: primaryColor || "#053A5E" }}
+          >
+            {buttonText}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CtaBanner;

--- a/components/emma-faq-section/components/FaqItem.js
+++ b/components/emma-faq-section/components/FaqItem.js
@@ -1,0 +1,49 @@
+// @flow
+import React from "react";
+
+const FaqItem = ({ question, answer, isExpanded, onToggle, isFirst, isLast }) => {
+  return (
+    <div>
+      <h2>
+        <button
+          type="button"
+          onClick={onToggle}
+          className={
+            (isLast && !isExpanded ? "rounded-b-xl " : "border-b-0 ") +
+            (isFirst ? "rounded-t-xl " : "") +
+            "flex items-center justify-between w-full p-5 font-medium rtl:text-right text-gray-700 border border-gray-200 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-800 dark:border-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 gap-3 transition-colors"
+          }
+          aria-expanded={isExpanded}
+        >
+          <span className="text-left">{question}</span>
+          <svg
+            className={`w-4 h-4 shrink-0 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 10 6"
+          >
+            <path
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M9 5 5 1 1 5"
+            />
+          </svg>
+        </button>
+      </h2>
+      <div className={isExpanded ? "" : "hidden"}>
+        <div
+          className={
+            (isLast ? "rounded-b-xl " : "border-b-0 ") +
+            "p-5 text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-700 dark:bg-gray-900 leading-relaxed"
+          }
+          dangerouslySetInnerHTML={{ __html: answer }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default FaqItem;

--- a/components/emma-faq-section/index.js
+++ b/components/emma-faq-section/index.js
@@ -1,0 +1,84 @@
+// @flow
+import React, { useState } from "react";
+import FaqItem from "./components/FaqItem.js";
+import CtaBanner from "./components/CtaBanner.js";
+import "../source/style/style.css";
+
+type FaqItemType = {
+  question: string,
+  answer: string,
+};
+
+type Props = {
+  faqHeading: string,
+  faqItems: Array<FaqItemType>,
+  ctaHeading: string,
+  ctaDescription: string,
+  ctaButtonText: string,
+  ctaButtonLink: string,
+  primaryColor__limio_color: string,
+  componentId: string,
+};
+
+function EmmaFaqSection({
+  faqHeading,
+  faqItems = [],
+  ctaHeading,
+  ctaDescription,
+  ctaButtonText,
+  ctaButtonLink,
+  primaryColor__limio_color,
+  componentId,
+}: Props): React.Node {
+  const [activeIndex, setActiveIndex] = useState(null);
+
+  const handleToggle = (index) => {
+    setActiveIndex(activeIndex === index ? null : index);
+  };
+
+  return (
+    <section className="bg-white dark:bg-gray-900" id={componentId}>
+      <div className="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+        {/* FAQ Section */}
+        {faqHeading && (
+          <div className="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
+            <h2 className="mb-4 text-3xl sm:text-4xl tracking-tight font-extrabold text-gray-900 dark:text-white">
+              {faqHeading}
+            </h2>
+          </div>
+        )}
+
+        {faqItems.length > 0 && (
+          <div className="mx-auto max-w-screen-lg">
+            {faqItems.map((item, i) => (
+              <FaqItem
+                key={`faq-${i}`}
+                question={item.question}
+                answer={item.answer}
+                isExpanded={activeIndex === i}
+                onToggle={() => handleToggle(i)}
+                isFirst={i === 0}
+                isLast={i === faqItems.length - 1}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* CTA Banner */}
+        {ctaHeading && (
+          <div className="mx-auto max-w-screen-lg">
+            <CtaBanner
+              heading={ctaHeading}
+              description={ctaDescription}
+              buttonText={ctaButtonText || "Let's chat"}
+              buttonLink={ctaButtonLink || "#"}
+              primaryColor={primaryColor__limio_color}
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default EmmaFaqSection;

--- a/components/emma-faq-section/package.json
+++ b/components/emma-faq-section/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "component-emma-faq-section",
+  "version": "1.0.0",
+  "description": "Emma-style FAQ accordion with professional services CTA banner",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "faqHeading",
+      "label": "FAQ Heading",
+      "type": "string",
+      "default": "Frequently Asked Questions"
+    },
+    {
+      "id": "faqItems",
+      "label": "FAQ Items",
+      "type": "list",
+      "fields": {
+        "question": {
+          "id": "question",
+          "label": "Question",
+          "type": "string"
+        },
+        "answer": {
+          "id": "answer",
+          "label": "Answer",
+          "type": "richText"
+        }
+      },
+      "default": [
+        {
+          "question": "Who is eligible for these plans?",
+          "answer": "<p>These plans are available for new customers purchasing from July 21, 2022.</p>"
+        },
+        {
+          "question": "What if I have more than 10,000 contacts?",
+          "answer": "<p>If you have more than 10,000 contacts, please contact us for a custom quote tailored to your needs.</p>"
+        }
+      ]
+    },
+    {
+      "id": "ctaHeading",
+      "label": "CTA Heading",
+      "type": "string",
+      "default": "Get expert help when you need it"
+    },
+    {
+      "id": "ctaDescription",
+      "label": "CTA Description",
+      "type": "string",
+      "default": "Our Professional Services team can help you build long-term brand loyalty, maximize marketing success, and drive optimal business results."
+    },
+    {
+      "id": "ctaButtonText",
+      "label": "CTA Button Text",
+      "type": "string",
+      "default": "Let's chat"
+    },
+    {
+      "id": "ctaButtonLink",
+      "label": "CTA Button Link",
+      "type": "string",
+      "default": "/contact"
+    },
+    {
+      "id": "primaryColor__limio_color",
+      "label": "Primary color",
+      "type": "color",
+      "default": "#053A5E"
+    },
+    {
+      "id": "componentId",
+      "label": "Component ID",
+      "type": "string",
+      "default": "emma-faq-section"
+    }
+  ]
+}

--- a/components/emma-feature-comparison/components/ComparisonCategory.js
+++ b/components/emma-feature-comparison/components/ComparisonCategory.js
@@ -1,0 +1,28 @@
+// @flow
+import React from "react";
+import FeatureRow from "./FeatureRow.js";
+
+const ComparisonCategory = ({ category }) => {
+  const { name, features } = category;
+
+  return (
+    <div className="mb-2">
+      <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 rounded-t-lg">
+        <h3 className="text-sm font-bold text-gray-900 dark:text-white uppercase tracking-wide">
+          {name}
+        </h3>
+      </div>
+      <div>
+        {features.map((feature, i) => (
+          <FeatureRow
+            key={`${feature.name}-${i}`}
+            feature={feature}
+            isLast={i === features.length - 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ComparisonCategory;

--- a/components/emma-feature-comparison/components/FeatureRow.js
+++ b/components/emma-feature-comparison/components/FeatureRow.js
@@ -1,0 +1,52 @@
+// @flow
+import React from "react";
+
+const CheckIcon = () => (
+  <svg className="w-5 h-5 text-blue-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+    <path
+      fillRule="evenodd"
+      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const CrossIcon = () => (
+  <svg className="w-5 h-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+    <path
+      fillRule="evenodd"
+      d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const renderValue = (value) => {
+  if (value === true) return <CheckIcon />;
+  if (value === false) return <CrossIcon />;
+  return <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">{value}</span>;
+};
+
+const FeatureRow = ({ feature, isLast }) => {
+  const { name, values, isNew } = feature;
+
+  return (
+    <div className={`grid grid-cols-5 items-center py-3 px-4 ${!isLast ? "border-b border-gray-100 dark:border-gray-700" : ""} hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors`}>
+      <div className="col-span-1 flex items-center gap-2">
+        <span className="text-sm text-gray-600 dark:text-gray-300">{name}</span>
+        {isNew && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+            New
+          </span>
+        )}
+      </div>
+      {values.map((value, i) => (
+        <div key={`${name}-${i}`} className="col-span-1 flex justify-center">
+          {renderValue(value)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FeatureRow;

--- a/components/emma-feature-comparison/data/features.js
+++ b/components/emma-feature-comparison/data/features.js
@@ -1,0 +1,99 @@
+// @flow
+
+export const defaultPlans = ["Emma Lite", "Emma Essentials", "Emma for Teams", "Emma Corporate"];
+
+export const defaultCategories = [
+  {
+    name: "Account Management",
+    features: [
+      { name: "Tiered account structure", values: ["2 subaccounts", "2 subaccounts", "5+ subaccounts", "10+ subaccounts"] },
+      { name: "Users", values: ["5", "10", "25", "Unlimited"] },
+      { name: "User role types", values: ["2", "5", "6", "6"] },
+      { name: "Unlimited email sending", values: [true, true, true, true] },
+      { name: "Custom user permissions", values: [false, false, true, true] },
+      { name: "Approvals dashboard", values: [false, true, true, true] },
+      { name: "Activity dashboard", values: [false, true, true, true] },
+      { name: "Subaccount categories", values: [false, false, true, true] },
+      { name: "Private branding", values: [false, true, true, true] },
+    ],
+  },
+  {
+    name: "Marketing Channels & Tools",
+    features: [
+      { name: "Email", values: [true, true, true, true] },
+      { name: "Email scheduling", values: [true, true, true, true] },
+      { name: "Smart send", values: [true, true, true, true], isNew: true },
+      { name: "Marketing calendar", values: [false, true, true, true] },
+      { name: "Signup forms", values: [true, true, true, true] },
+      { name: "Landing pages", values: [false, true, true, true] },
+      { name: "SMS", values: [false, true, true, true] },
+    ],
+  },
+  {
+    name: "Brand Manager",
+    features: [
+      { name: "Style Guide", values: [false, "Limited", true, true] },
+      { name: "Template & campaign sharing", values: [false, false, true, true] },
+      { name: "Subject and Preheader Locking", values: [false, false, true, true] },
+      { name: "Asset sharing", values: [false, false, true, true] },
+      { name: "Template folder sharing", values: [false, false, true, true] },
+    ],
+  },
+  {
+    name: "Design",
+    features: [
+      { name: "Drag & drop email editor", values: [true, true, true, true] },
+      { name: "Save Email Rows", values: [false, false, true, true] },
+      { name: "AI Assistant", values: [true, true, true, true] },
+      { name: "Email template gallery", values: [true, true, true, true] },
+      { name: "Code your own emails", values: [false, true, true, true] },
+      { name: "Asset library", values: [true, true, true, true] },
+    ],
+  },
+  {
+    name: "Automation",
+    features: [
+      { name: "Automation builder", values: ["1 journey", "Unlimited", "Unlimited", "Unlimited"] },
+      { name: "Multiple starting points", values: [false, true, true, true] },
+      { name: "Branching points", values: [false, true, true, true] },
+      { name: "Custom event-driven automations", values: [false, true, true, true] },
+    ],
+  },
+  {
+    name: "Audience",
+    features: [
+      { name: "Segmentation", values: [true, true, true, true] },
+      { name: "Smart segment", values: [true, true, true, true], isNew: true },
+      { name: "Dynamic content", values: [true, true, true, true] },
+      { name: "Subscription management", values: [true, true, true, true] },
+      { name: "Contact view across subaccounts", values: [false, false, false, true], isNew: true },
+      { name: "Audience sharing", values: [false, false, false, true] },
+    ],
+  },
+  {
+    name: "Insights & Optimization",
+    features: [
+      { name: "Real-time reporting", values: [true, true, true, true] },
+      { name: "Comparative reporting", values: [false, true, true, true] },
+      { name: "Trends reporting", values: [false, false, true, true] },
+      { name: "Pre-send email testing", values: [true, true, true, true] },
+      { name: "A/B subject line split testing", values: [true, true, true, true] },
+      { name: "A/B content split testing", values: [false, true, true, true] },
+      { name: "Integrations", values: [true, true, true, true] },
+      { name: "API access", values: [true, true, true, true] },
+    ],
+  },
+  {
+    name: "Help & Support",
+    features: [
+      { name: "In-app support", values: [true, true, true, true] },
+      { name: "Email support", values: [true, true, true, true] },
+      { name: "Phone support", values: [true, true, true, true] },
+      { name: "Priority support", values: [false, false, false, true] },
+      { name: "Deliverability support", values: [true, true, true, true] },
+      { name: "Help center", values: [true, true, true, true] },
+      { name: "Training videos", values: [true, true, true, true] },
+      { name: "Single sign-on", values: [false, false, true, true] },
+    ],
+  },
+];

--- a/components/emma-feature-comparison/index.js
+++ b/components/emma-feature-comparison/index.js
@@ -1,0 +1,133 @@
+// @flow
+import React, { useState } from "react";
+import ComparisonCategory from "./components/ComparisonCategory.js";
+import { defaultPlans, defaultCategories } from "./data/features.js";
+import "../source/style/style.css";
+
+type Feature = {
+  name: string,
+  values: Array<boolean | string>,
+  isNew?: boolean,
+};
+
+type Category = {
+  name: string,
+  features: Array<Feature>,
+};
+
+type Props = {
+  heading: string,
+  plans: Array<string>,
+  categories: Array<Category>,
+  componentId: string,
+};
+
+function EmmaFeatureComparison({
+  heading,
+  plans,
+  categories,
+  componentId,
+}: Props): React.Node {
+  const planNames = plans && plans.length > 0 ? plans : defaultPlans;
+  const featureCategories = categories && categories.length > 0 ? categories : defaultCategories;
+
+  // Mobile: select a plan to view
+  const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
+
+  return (
+    <section className="bg-white dark:bg-gray-900" id={componentId}>
+      <div className="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+        {heading && (
+          <div className="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
+            <h2 className="mb-4 text-3xl sm:text-4xl tracking-tight font-extrabold text-gray-900 dark:text-white">
+              {heading}
+            </h2>
+          </div>
+        )}
+
+        {/* Mobile plan selector */}
+        <div className="lg:hidden mb-6">
+          <select
+            value={selectedPlanIndex}
+            onChange={(e) => setSelectedPlanIndex(Number(e.target.value))}
+            className="w-full p-3 border border-gray-200 rounded-lg text-gray-900 dark:text-white dark:bg-gray-800 dark:border-gray-600 focus:ring-2 focus:ring-blue-200"
+          >
+            {planNames.map((plan, i) => (
+              <option key={`plan-select-${i}`} value={i}>
+                {plan}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Mobile view: single plan */}
+        <div className="lg:hidden">
+          {featureCategories.map((category, catIdx) => (
+            <div key={`mobile-cat-${catIdx}`} className="mb-4">
+              <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 rounded-t-lg">
+                <h3 className="text-sm font-bold text-gray-900 dark:text-white uppercase tracking-wide">
+                  {category.name}
+                </h3>
+              </div>
+              {category.features.map((feature, featIdx) => {
+                const value = feature.values[selectedPlanIndex];
+                return (
+                  <div
+                    key={`mobile-feat-${catIdx}-${featIdx}`}
+                    className={`flex items-center justify-between py-3 px-4 ${featIdx < category.features.length - 1 ? "border-b border-gray-100 dark:border-gray-700" : ""}`}
+                  >
+                    <span className="text-sm text-gray-600 dark:text-gray-300 flex items-center gap-2">
+                      {feature.name}
+                      {feature.isNew && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                          New
+                        </span>
+                      )}
+                    </span>
+                    <span>
+                      {value === true ? (
+                        <svg className="w-5 h-5 text-blue-300" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      ) : value === false ? (
+                        <svg className="w-5 h-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                        </svg>
+                      ) : (
+                        <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">{value}</span>
+                      )}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        {/* Desktop view: full comparison table */}
+        <div className="hidden lg:block">
+          {/* Sticky header */}
+          <div className="sticky top-0 z-10 bg-white dark:bg-gray-900 border-b-2 border-gray-200 dark:border-gray-600">
+            <div className="grid grid-cols-5 items-center py-4 px-4">
+              <div className="col-span-1">
+                <span className="text-sm font-bold text-gray-500 dark:text-gray-400 uppercase">Features</span>
+              </div>
+              {planNames.map((plan, i) => (
+                <div key={`header-${i}`} className="col-span-1 text-center">
+                  <span className="text-sm font-bold text-gray-900 dark:text-white">{plan}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Feature categories */}
+          {featureCategories.map((category, i) => (
+            <ComparisonCategory key={`category-${i}`} category={category} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default EmmaFeatureComparison;

--- a/components/emma-feature-comparison/package.json
+++ b/components/emma-feature-comparison/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "component-emma-feature-comparison",
+  "version": "1.0.0",
+  "description": "Emma-style feature comparison table for pricing tiers",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "heading",
+      "label": "Heading",
+      "type": "string",
+      "default": "Compare plans"
+    },
+    {
+      "id": "componentId",
+      "label": "Component ID",
+      "type": "string",
+      "default": "emma-feature-comparison"
+    }
+  ]
+}

--- a/components/emma-pricing-cards/components/PricingCard.js
+++ b/components/emma-pricing-cards/components/PricingCard.js
@@ -1,0 +1,96 @@
+// @flow
+import React from "react";
+import { useBasket } from "@limio/sdk";
+import { sanitizeString, formatDisplayPrice } from "../../source/utils/string";
+
+const PricingCard = ({ offer, primaryColor, ctaColor }) => {
+  const { addToBasket } = useBasket();
+
+  const {
+    display_name__limio,
+    display_price__limio,
+    display_description__limio,
+    offer_features__limio,
+    price__limio,
+    cta_text__limio,
+    best_value__limio,
+  } = offer.data.attributes;
+
+  const isContactUs = !price__limio || price__limio.length === 0;
+  const ctaText = cta_text__limio || (isContactUs ? "Let's talk" : "Request a demo");
+
+  const formatBulletPoints = (string) => {
+    const sanitised = sanitizeString(string);
+    const features = document.createElement("div");
+    features.innerHTML = sanitised;
+
+    return [].slice.call(features.children).map((feature, i) => (
+      <li className="flex items-center space-x-3" key={`${feature.innerText}-${i}`}>
+        <svg className="flex-shrink-0 w-5 h-5 text-blue-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+          <path
+            fillRule="evenodd"
+            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+        <span className="text-gray-700 dark:text-gray-300">{feature.innerText}</span>
+      </li>
+    ));
+  };
+
+  return (
+    <div
+      className="flex flex-col bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 shadow-sm hover:shadow-lg hover:border-[#053A5E] hover:-translate-y-0.5 transition-all duration-200 p-6 xl:p-8"
+      style={{ minHeight: "500px" }}
+    >
+      <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+        {display_name__limio}
+      </h3>
+
+      <div className="mb-4">
+        {isContactUs ? (
+          <span className="text-2xl font-extrabold text-gray-900 dark:text-white">Contact us</span>
+        ) : (
+          <div className="flex items-baseline">
+            <span
+              className="text-3xl font-extrabold text-gray-900 dark:text-white"
+              dangerouslySetInnerHTML={{
+                __html: sanitizeString(
+                  formatDisplayPrice(display_price__limio, [
+                    { currencyCode: price__limio[0].currencyCode, value: price__limio[0].value },
+                  ])
+                ),
+              }}
+            />
+          </div>
+        )}
+        {!isContactUs && (
+          <p className="text-sm text-gray-400 mt-1">with annual contract</p>
+        )}
+      </div>
+
+      {display_description__limio && (
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 leading-relaxed">
+          {display_description__limio}
+        </p>
+      )}
+
+      <ul role="list" className="mb-8 space-y-3 text-left flex-grow">
+        {offer_features__limio && formatBulletPoints(offer_features__limio)}
+      </ul>
+
+      <button
+        onClick={() => addToBasket(offer)}
+        className="w-full rounded-lg px-5 py-3 text-center text-sm font-semibold transition-colors duration-200 focus:ring-4 focus:ring-blue-200"
+        style={{
+          backgroundColor: ctaColor || primaryColor || "#053A5E",
+          color: "#ffffff",
+        }}
+      >
+        {ctaText}
+      </button>
+    </div>
+  );
+};
+
+export default PricingCard;

--- a/components/emma-pricing-cards/index.js
+++ b/components/emma-pricing-cards/index.js
@@ -1,0 +1,65 @@
+// @flow
+import React, { useEffect } from "react";
+import { useCampaign } from "@limio/sdk";
+import PricingCard from "./components/PricingCard.js";
+import "../source/style/style.css";
+
+type Props = {
+  heading: string,
+  subheading: string,
+  primaryColor__limio_color: string,
+  ctaColor__limio_color: string,
+  componentId: string,
+};
+
+function EmmaPricingCards({
+  heading,
+  subheading,
+  primaryColor__limio_color,
+  ctaColor__limio_color,
+  componentId,
+}: Props): React.Node {
+  const { offers = [] } = useCampaign();
+
+  useEffect(() => {
+    typeof performance !== "undefined" && performance?.mark?.("emma-pricing-cards-init");
+  }, []);
+
+  return (
+    <section className="bg-white dark:bg-gray-900" id={componentId}>
+      <div className="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+        {(heading || subheading) && (
+          <div className="mx-auto max-w-screen-lg text-center mb-8 lg:mb-12">
+            {heading && (
+              <h2 className="mb-4 text-3xl sm:text-4xl lg:text-5xl tracking-tight font-extrabold text-gray-900 dark:text-white leading-tight">
+                {heading}
+              </h2>
+            )}
+            {subheading && (
+              <p className="font-light text-gray-500 text-lg sm:text-xl dark:text-gray-400">
+                {subheading}
+              </p>
+            )}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+          {offers.length > 0 ? (
+            offers.map((offer, i) => (
+              <PricingCard
+                key={`${offer.path || offer.id}-${i}`}
+                offer={offer}
+                primaryColor={primaryColor__limio_color}
+                ctaColor={ctaColor__limio_color}
+              />
+            ))
+          ) : (
+            <p className="text-gray-500 col-span-full text-center">No offers to display...</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default EmmaPricingCards;

--- a/components/emma-pricing-cards/package.json
+++ b/components/emma-pricing-cards/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "component-emma-pricing-cards",
+  "version": "1.0.0",
+  "description": "Emma-style pricing tier cards with offer data from Limio SDK",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "heading",
+      "label": "Heading",
+      "type": "string",
+      "default": "Flexible plans for teams of all sizes."
+    },
+    {
+      "id": "subheading",
+      "label": "Subheading",
+      "type": "string",
+      "default": "Prices starting at $99/month."
+    },
+    {
+      "id": "primaryColor__limio_color",
+      "label": "Primary color",
+      "type": "color",
+      "default": "#053A5E"
+    },
+    {
+      "id": "ctaColor__limio_color",
+      "label": "CTA button color",
+      "type": "color",
+      "default": "#053A5E"
+    },
+    {
+      "id": "componentId",
+      "label": "Component ID",
+      "type": "string",
+      "default": "emma-pricing-cards"
+    }
+  ]
+}

--- a/components/emma-pricing-hero/index.js
+++ b/components/emma-pricing-hero/index.js
@@ -1,0 +1,28 @@
+// @flow
+import React from "react";
+import "../source/style/style.css";
+
+type Props = {
+  heading: string,
+  subheading: string,
+  componentId: string,
+};
+
+function EmmaPricingHero({ heading, subheading, componentId }: Props): React.Node {
+  return (
+    <section className="bg-white dark:bg-gray-900" id={componentId}>
+      <div className="py-12 px-4 mx-auto max-w-screen-xl lg:py-20 lg:px-6">
+        <div className="mx-auto max-w-screen-lg text-center">
+          <h1 className="mb-4 text-3xl sm:text-4xl lg:text-5xl tracking-tight font-extrabold text-gray-900 dark:text-white leading-tight">
+            {heading}
+          </h1>
+          <p className="font-light text-gray-500 text-lg sm:text-xl dark:text-gray-400">
+            {subheading}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default EmmaPricingHero;

--- a/components/emma-pricing-hero/package.json
+++ b/components/emma-pricing-hero/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "component-emma-pricing-hero",
+  "version": "1.0.0",
+  "description": "Emma-style pricing page hero heading section",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "heading",
+      "label": "Heading",
+      "type": "string",
+      "default": "Flexible plans for teams of all sizes."
+    },
+    {
+      "id": "subheading",
+      "label": "Subheading",
+      "type": "string",
+      "default": "Prices starting at $99/month."
+    },
+    {
+      "id": "componentId",
+      "label": "Component ID",
+      "type": "string",
+      "default": "emma-pricing-hero"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added 4 new Limio custom components replicating the myemma.com/pricing page
- **emma-pricing-hero**: Headline and subheading hero section
- **emma-pricing-cards**: Pricing tier cards using `useCampaign`/`useBasket` SDK hooks with responsive grid layout
- **emma-feature-comparison**: Responsive feature comparison table with 8 categories, mobile plan selector, and desktop full-table view
- **emma-faq-section**: FAQ accordion with expand/collapse and professional services CTA banner

## Test plan
- [ ] Verify all 4 components render in Storybook (`cd component-playground && yarn limio`)
- [ ] Test responsive layouts at mobile, tablet, and desktop breakpoints
- [ ] Verify FAQ accordion expand/collapse behavior
- [ ] Verify feature comparison mobile plan selector
- [ ] Deploy to saas-dev catalog page and verify in Page Builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Emma FAQ Section component with expandable/collapsible question-and-answer items and optional call-to-action banner
  * Added Emma Feature Comparison component to display plan features side-by-side for easy comparison
  * Added Emma Pricing Cards component to showcase pricing tiers with feature highlights and call-to-action buttons
  * Added Emma Pricing Hero section component for pricing page headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->