### PR TITLE
Fix pricing-cards group toggle showing all system values

### DIFF
--- a/components/pricing-cards/index.js
+++ b/components/pricing-cards/index.js
@@ -109,8 +109,16 @@ const PricingCards = () => {
     pageOptions,
   } = useBasket() || {}
 
-  const hasGroups = groupValues.length > 1
-  const [activeGroup, setActiveGroup] = useState(groupValues[0]?.id || null)
+  // Derive active groups from actual offers rather than all possible groupValues
+  const offerGroupIds = [...new Set(
+    offers
+      .map((o) => o?.data?.attributes?.group__limio)
+      .filter(Boolean)
+  )]
+  const activeGroups = groupValues.filter((g) => offerGroupIds.includes(g.id))
+
+  const hasGroups = activeGroups.length > 1
+  const [activeGroup, setActiveGroup] = useState(activeGroups[0]?.id || null)
 
   const filteredOffers = hasGroups
     ? offers.filter((offer) => {
@@ -140,7 +148,7 @@ const PricingCards = () => {
   return (
     <section id={componentId} className="pricing-cards">
       <GroupToggle
-        groupValues={groupValues}
+        groupValues={activeGroups}
         activeGroup={activeGroup}
         onGroupChange={setActiveGroup}
         primaryColor={primaryColor}


### PR DESCRIPTION
## Summary
- **Fix group toggle showing all system-wide values** — `groupValues` from `useCampaign()` returns ALL possible groups configured in the system, not just those on the current page's offers. The toggle now derives active groups from the actual offers' `group__limio` attributes so only relevant groups appear.

**Root cause:** The previous code used `groupValues` directly from `useCampaign()` which includes every group configured system-wide (Monthly, Yearly, 2-Years Plan, Quarterly, Consultations, Outright Add On, Basic, Premium, Essentials, Advanced, Elite, etc.). The fix filters `groupValues` to only include groups that match `group__limio` on the page's offers.

**Note:** This fix was intended for PR #21 but was missed in the merge. PR #22 only included the version bump.

## Changes
```javascript
// Before (broken) — uses ALL system groupValues
const hasGroups = groupValues.length > 1

// After (fixed) — derives from actual offers
const offerGroupIds = [...new Set(
  offers.map((o) => o?.data?.attributes?.group__limio).filter(Boolean)
)]
const activeGroups = groupValues.filter((g) => offerGroupIds.includes(g.id))
const hasGroups = activeGroups.length > 1
```

## Test plan
- Verify toggle only shows groups present on the page's offers (e.g. Monthly/Annual for Emma)
- Verify switching groups filters the pricing cards correctly
- Verify pages with no group offers show no toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)