### PR TITLE
Fix richText props for Limio page builder

### DIFF
--- a/component-playground/src/stories/LossBenefitCancel.stories.js
+++ b/component-playground/src/stories/LossBenefitCancel.stories.js
@@ -108,7 +108,7 @@ const defaultArgs = {
     subheading: "If you cancel your subscription, you'll no longer have access to these features:",
     primaryColor: "#002C5F",
     dangerColor: "#dc2626",
-    offerFeatures: "{{data.attributes.offer_features__limio}}",
+    offerFeatures__limio_richtext: "{{data.attributes.offer_features__limio}}",
     planName: "{{data.attributes.display_name__limio}}",
     displayPrice: "{{data.attributes.display_price__limio}}",
     fallbackFeatures__limio_richtext: "<ul><li>Access to all plan features</li><li>Customer support</li><li>Regular updates</li></ul>",

--- a/components/loss-benefit-cancel/index.js
+++ b/components/loss-benefit-cancel/index.js
@@ -18,7 +18,7 @@ function LossBenefitCancel() {
         subheading = "If you cancel your subscription, you'll no longer have access to these features:",
         primaryColor = "#002C5F",
         dangerColor = "#dc2626",
-        offerFeatures = "{{data.attributes.offer_features__limio}}",
+        offerFeatures__limio_richtext: offerFeatures = "{{data.attributes.offer_features__limio}}",
         planName = "{{data.attributes.display_name__limio}}",
         displayPrice = "{{data.attributes.display_price__limio}}",
         fallbackFeatures__limio_richtext = "<ul><li>Access to all plan features</li><li>Customer support</li><li>Regular updates</li></ul>",

--- a/components/loss-benefit-cancel/package.json
+++ b/components/loss-benefit-cancel/package.json
@@ -35,9 +35,9 @@
       "default": "#dc2626"
     },
     {
-      "id": "offerFeatures",
+      "id": "offerFeatures__limio_richtext",
       "label": "Offer features template",
-      "type": "richText",
+      "type": "richtext",
       "default": "{{data.attributes.offer_features__limio}}"
     },
     {
@@ -55,7 +55,7 @@
     {
       "id": "fallbackFeatures__limio_richtext",
       "label": "Fallback features (if offer has none)",
-      "type": "richText",
+      "type": "richtext",
       "default": "<ul><li>Access to all plan features</li><li>Customer support</li><li>Regular updates</li></ul>"
     },
     {


### PR DESCRIPTION
## Summary
- Renamed `offerFeatures` prop id to `offerFeatures__limio_richtext` (Limio requires `__limio_richtext` suffix for richtext props)
- Changed `type` from `"richText"` to `"richtext"` (lowercase per Limio docs) for both richtext props
- Updated component destructuring and stories to match

## Test plan
- [x] Verified in Storybook — component renders correctly with resolved offer data
- [x] Verify both richtext props now appear in Limio page builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized property naming and field type formatting in the Loss Benefit Cancel component configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->