### PR TITLE
Add new subscription overview component

### DIFF
--- a/components/subscription-summary-table/SubscriptionSummaryTable.tsx
+++ b/components/subscription-summary-table/SubscriptionSummaryTable.tsx
@@ -23,6 +23,24 @@ type Props = {
   componentId: string
 }
 
+type SubscriptionContentProps = {
+  ownerId: string | null
+  subRef: string | null
+  notFoundText: string
+  onToast: (key: string, message: string, variant?: "success" | "error" | "warning" | "info") => void
+}
+
+function SubscriptionContent({ ownerId, subRef, notFoundText, onToast }: SubscriptionContentProps): React.JSX.Element {
+  const { subscriptions: allSubscriptions } = useSubscriptions({ ownerId })
+  const subscriptions = subRef ? allSubscriptions.filter((sub: { name?: string }) => sub.name === subRef) : allSubscriptions
+
+  if (subscriptions.length < 1) {
+    return <ErrorMessage text={notFoundText} icon={<ErrorIcon style={{ height: "50px", width: "50px" }} />} />
+  }
+
+  return <Subscriptions subscriptions={subscriptions} onToast={onToast} />
+}
+
 export function SubscriptionSummaryTable({ componentId, notFoundText__limio_richtext }: Props): React.JSX.Element {
   const [toasts, setToasts] = useState<Record<string, Toast>>({})
   const { offerChipColor } = useComponentStaticProps()
@@ -33,13 +51,6 @@ export function SubscriptionSummaryTable({ componentId, notFoundText__limio_rich
   const params = new URLSearchParams(window.location.search)
   const ownerId = params.get("ownerId")
   const subRef = params.get("subRef")
-  const { subscriptions: allSubscriptions } = useSubscriptions({ ownerId })
-  const subscriptions = subRef ? allSubscriptions.filter((sub: { name?: string }) => sub.name === subRef) : allSubscriptions
-
-  //show error text if no subscription data is available
-  if (subscriptions.length < 1) {
-    return <ErrorMessage text={notFoundText__limio_richtext} icon={<ErrorIcon style={{ height: "50px", width: "50px" }} />} />
-  }
 
   return (
     <ThemeProvider theme={theme}>
@@ -72,7 +83,7 @@ export function SubscriptionSummaryTable({ componentId, notFoundText__limio_rich
               </Box>
 
               {/* Subscriptions */}
-              <Subscriptions subscriptions={subscriptions} onToast={showToast} />
+              <SubscriptionContent ownerId={ownerId} subRef={subRef} notFoundText={notFoundText__limio_richtext} onToast={showToast} />
             </Suspense>
           </ErrorBoundary>
         </Container>

--- a/components/subscription-summary-table/SubscriptionSummaryTable.tsx
+++ b/components/subscription-summary-table/SubscriptionSummaryTable.tsx
@@ -1,0 +1,99 @@
+import * as React from "react"
+import { useState, Suspense } from "react"
+import { Subscriptions } from "./components/Subscriptions"
+import { useSubscriptions } from "@limio/sdk"
+import { ErrorBoundary } from "@limio/sdk"
+import { ErrorMessage } from "./helpers/ErrorMessage"
+import { useComponentStaticProps } from "./componentStaticProps"
+import { Box, Snackbar, Alert, Container, createTheme, ThemeProvider } from "@mui/material"
+import ErrorIcon from "@mui/icons-material/Error"
+import "./styles/index.css"
+
+const theme = createTheme({
+  typography: {
+    fontFamily: "'Open Sans', sans-serif"
+  },
+  spacing: 16
+})
+
+type Toast = { show: boolean; message: string; variant?: "success" | "error" | "warning" | "info" }
+
+type Props = {
+  notFoundText__limio_richtext: string
+  componentId: string
+}
+
+export function SubscriptionSummaryTable({ componentId, notFoundText__limio_richtext }: Props): React.JSX.Element {
+  const [toasts, setToasts] = useState<Record<string, Toast>>({})
+  const { offerChipColor } = useComponentStaticProps()
+
+  const showToast = (key: string, message: string, variant: "success" | "error" | "warning" | "info" = "error") =>
+    setToasts(prev => ({ ...prev, [key]: { show: true, message, variant } }))
+
+  const params = new URLSearchParams(window.location.search)
+  const ownerId = params.get("ownerId")
+  const subRef = params.get("subRef")
+  const { subscriptions: allSubscriptions } = useSubscriptions({ ownerId })
+  const subscriptions = subRef ? allSubscriptions.filter((sub: { name?: string }) => sub.name === subRef) : allSubscriptions
+
+  //show error text if no subscription data is available
+  if (subscriptions.length < 1) {
+    return <ErrorMessage text={notFoundText__limio_richtext} icon={<ErrorIcon style={{ height: "50px", width: "50px" }} />} />
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box className="subscription-summary" style={{ "--accent-color": offerChipColor } as React.CSSProperties} sx={{ backgroundColor: "#fff", pt: 2, pb: 6 }}>
+        <Container sx={{ width: { lg: "1050px" } }} id={componentId}>
+          <ErrorBoundary ErrorUI={() => <ErrorMessage text={notFoundText__limio_richtext} icon={<ErrorIcon style={{ height: "50px", width: "50px" }} />} />}>
+            <Suspense fallback={<SubscriptionSummaryTable.Skeleton />}>
+              {/* Toasts */}
+              <Box sx={{ position: "relative", zIndex: 10 }}>
+                {Object.keys(toasts).map((notification) => {
+                  const { show, message, variant = "success" } = toasts[notification]
+
+                  return (
+                    <Snackbar
+                      key={notification}
+                      open={show}
+                      autoHideDuration={6000}
+                      onClose={() =>
+                        setToasts(prev => ({
+                          ...prev,
+                          [notification]: { ...prev[notification], show: false }
+                        }))
+                      }
+                      anchorOrigin={{ vertical: "top", horizontal: "center" }}
+                    >
+                      <Alert severity={variant}>{message}</Alert>
+                    </Snackbar>
+                  )
+                })}
+              </Box>
+
+              {/* Subscriptions */}
+              <Subscriptions subscriptions={subscriptions} onToast={showToast} />
+            </Suspense>
+          </ErrorBoundary>
+        </Container>
+      </Box>
+    </ThemeProvider>
+  )
+}
+
+SubscriptionSummaryTable.Skeleton = () => (
+  <ThemeProvider theme={theme}>
+    <Box
+      sx={{
+        backgroundColor: "#fff",
+        pt: 2,
+        pb: 6,
+        mx: "auto"
+      }}
+    >
+      <Subscriptions.Skeleton />
+    </Box>
+  </ThemeProvider>
+)
+
+export default SubscriptionSummaryTable

--- a/components/subscription-summary-table/componentStaticProps.ts
+++ b/components/subscription-summary-table/componentStaticProps.ts
@@ -1,0 +1,46 @@
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+import packageData from "./package.json"
+
+type StaticProps = {
+  notFoundText__limio_richtext: string
+  componentId: string
+  subscriptionIdLabel: string
+  showCancelButton: boolean
+  cancelButtonText: string
+  cancelButtonLink: string
+  minimumDaysNotice: number
+  requestCancellationLink: string
+  insufficientNoticeModalTitle: string
+  insufficientNoticeModalBody: string
+  insufficientNoticeConfirmText: string
+  insufficientNoticeCancelText: string
+  cancellationErrorMessage: string
+  showCancellationModal: boolean
+  showUpdateButton: boolean
+  updateButtonText: string
+  updateButtonLink: string
+  pageTitle: string
+  pageSubtitle: string
+  billingPlanColumnLabel: string
+  unitPriceColumnLabel: string
+  existingQuantityColumnLabel: string
+  billThroughDateColumnLabel: string
+  showEditAddOnsButton: boolean
+  editAddOnsButtonText: string
+  editAddOnsLink: string
+  showAddNewSubscriptionButton: boolean
+  addNewSubscriptionButtonText: string
+  addNewSubscriptionLink: string
+  offerRowColor: string
+  offerChipColor: string
+  addOnRowColor: string
+  addOnChipColor: string
+  primaryTextColor: string
+  renewalDateLabel: string
+}
+
+export function useComponentStaticProps(): StaticProps {
+  const defaultComponentProps = getPropsFromPackageJson(packageData)
+  const componentProps = useComponentProps<StaticProps>(defaultComponentProps)
+  return componentProps
+}

--- a/components/subscription-summary-table/components/CancellationNoticeModal.tsx
+++ b/components/subscription-summary-table/components/CancellationNoticeModal.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from "@mui/material"
+import "../styles/index.css"
+
+type CancellationNoticeModalProps = {
+  open: boolean
+  onClose: () => void
+  onConfirmRequest: () => void
+  modalTitle: string
+  modalBody: string
+  confirmButtonText: string
+  cancelButtonText: string
+}
+
+export function CancellationNoticeModal({
+  open,
+  onClose,
+  onConfirmRequest,
+  modalTitle,
+  modalBody,
+  confirmButtonText,
+  cancelButtonText
+}: CancellationNoticeModalProps): React.JSX.Element {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth className="subscription-modal">
+      <DialogTitle className="modal-title">{modalTitle}</DialogTitle>
+      <DialogContent>
+        <Typography variant="body1" color="#4D5359">
+          {modalBody}
+        </Typography>
+      </DialogContent>
+      <DialogActions className="modal-actions">
+        <Button onClick={onClose} variant="outlined" className="modal-btn-cancel">
+          {cancelButtonText}
+        </Button>
+        <Button onClick={onConfirmRequest} variant="contained" className="modal-btn-confirm">
+          {confirmButtonText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/components/subscription-summary-table/components/SubscriptionDetails.tsx
+++ b/components/subscription-summary-table/components/SubscriptionDetails.tsx
@@ -1,0 +1,142 @@
+import React from "react"
+import { formatCurrency, getCookie } from "@limio/sdk"
+import { getBillThroughDate } from "../helpers/Schedule"
+import { mapOfferToRow, mapAddOnToRow } from "../helpers/OfferDetails"
+import type { SubscriptionRowData } from "../helpers/OfferDetails"
+import { useComponentStaticProps } from "../componentStaticProps"
+import { Table, TableRow, TableCell, TableBody, Box, Typography, Chip } from "@mui/material"
+import type { Subscription, LimioObject, SubscriptionOffer, AddOn } from "@limio/types"
+import "../styles/index.css"
+
+const TOTAL_COLS = 8
+
+function formatPrice(rawPrice: { amount: number; currency?: string } | undefined, locale: string): string {
+  return rawPrice?.amount != null ? formatCurrency(rawPrice.amount, rawPrice.currency ?? "USD", locale) : "N/A"
+}
+
+type TableItem = SubscriptionRowData & {
+  key: string
+  rowColor: string
+  chipLabel: string
+  chipColor: string
+}
+
+export function SubscriptionDetails({
+  subscription,
+  currentOffers,
+  currentAddOns
+}: {
+  subscription: Subscription
+  currentOffers: LimioObject<SubscriptionOffer>[]
+  currentAddOns: AddOn[]
+}): React.JSX.Element {
+  const locale = getCookie("limio-country")
+  const {
+    offerRowColor,
+    offerChipColor,
+    addOnRowColor,
+    addOnChipColor,
+    primaryTextColor,
+    unitPriceColumnLabel,
+    existingQuantityColumnLabel,
+    billingPlanColumnLabel,
+    billThroughDateColumnLabel
+  } = useComponentStaticProps()
+
+  const billThroughDate = getBillThroughDate(subscription.schedule)
+
+  const priceFormatter = (rawPrice: { amount: number; currency?: string } | undefined) => formatPrice(rawPrice, locale)
+
+  const offerItems: TableItem[] = currentOffers.map((offer, i) => {
+    const { displayName, unitPrice, quantity, billingPlan } = mapOfferToRow(offer, priceFormatter)
+    return {
+      key: offer.id || `offer-${i}`,
+      displayName,
+      unitPrice,
+      quantity,
+      billingPlan,
+      rowColor: offerRowColor,
+      chipLabel: "Offer",
+      chipColor: offerChipColor
+    }
+  })
+
+  const addOnItems: TableItem[] = currentAddOns.map((addOn, i) => {
+    const { displayName, unitPrice, quantity, billingPlan } = mapAddOnToRow(addOn, priceFormatter)
+    return {
+      key: addOn.id || `addon-${i}`,
+      displayName,
+      unitPrice,
+      quantity,
+      billingPlan,
+      rowColor: addOnRowColor,
+      chipLabel: "Add-On",
+      chipColor: addOnChipColor
+    }
+  })
+
+  const tableItems: TableItem[] = offerItems.concat(addOnItems)
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Table
+        className="subscription-details-table"
+        size="small"
+        sx={{
+          width: "100%",
+          tableLayout: "auto",
+          "& td": { borderBottom: "none" },
+          borderCollapse: "collapse"
+        }}
+      >
+        <TableBody>
+          {tableItems.map(({ key, displayName, unitPrice, quantity, billingPlan, rowColor, chipLabel, chipColor }, idx) => (
+            <React.Fragment key={key}>
+              <TableRow>
+                <TableCell
+                  colSpan={TOTAL_COLS}
+                  sx={{
+                    backgroundColor: rowColor,
+                    borderBottom: "none",
+                    borderTop: idx > 0 ? "1px solid rgba(0,0,0,0.06)" : "none",
+                    px: 1.5,
+                    py: 0.875
+                  }}
+                >
+                  <Box display="flex" justifyContent="space-between" alignItems="center">
+                    <Typography variant="body2" fontWeight={600} color={primaryTextColor}>
+                      {displayName}
+                    </Typography>
+                    <Chip
+                      label={chipLabel}
+                      size="small"
+                      sx={{
+                        backgroundColor: chipColor,
+                        color: "#fff",
+                        fontWeight: 600,
+                        fontSize: "0.7rem",
+                        height: 20,
+                        borderRadius: "4px"
+                      }}
+                    />
+                  </Box>
+                </TableCell>
+              </TableRow>
+
+              <TableRow sx={{ backgroundColor: "#fff" }}>
+                <TableCell className="cell-base label-cell">{unitPriceColumnLabel}</TableCell>
+                <TableCell className="cell-base value-cell">{unitPrice}</TableCell>
+                <TableCell className="cell-base label-cell">{existingQuantityColumnLabel}</TableCell>
+                <TableCell className="cell-base value-cell">{quantity}</TableCell>
+                <TableCell className="cell-base label-cell">{billingPlanColumnLabel}</TableCell>
+                <TableCell className="cell-base value-cell">{billingPlan}</TableCell>
+                <TableCell className="cell-base label-cell">{billThroughDateColumnLabel}</TableCell>
+                <TableCell className="cell-base value-cell">{billThroughDate}</TableCell>
+              </TableRow>
+            </React.Fragment>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  )
+}

--- a/components/subscription-summary-table/components/SubscriptionDetails.tsx
+++ b/components/subscription-summary-table/components/SubscriptionDetails.tsx
@@ -1,36 +1,54 @@
-import React from "react"
-import { formatCurrency, getCookie } from "@limio/sdk"
-import { getBillThroughDate } from "../helpers/Schedule"
-import { mapOfferToRow, mapAddOnToRow } from "../helpers/OfferDetails"
-import type { SubscriptionRowData } from "../helpers/OfferDetails"
-import { useComponentStaticProps } from "../componentStaticProps"
-import { Table, TableRow, TableCell, TableBody, Box, Typography, Chip } from "@mui/material"
-import type { Subscription, LimioObject, SubscriptionOffer, AddOn } from "@limio/types"
-import "../styles/index.css"
+import React from "react";
+import { formatCurrency, getCookie } from "@limio/sdk";
+import { getBillThroughDate } from "../helpers/Schedule";
+import { mapOfferToRow, mapAddOnToRow } from "../helpers/OfferDetails";
+import type { SubscriptionRowData } from "../helpers/OfferDetails";
+import { useComponentStaticProps } from "../componentStaticProps";
+import {
+  Table,
+  TableRow,
+  TableCell,
+  TableBody,
+  Box,
+  Typography,
+  Chip,
+} from "@mui/material";
+import type {
+  Subscription,
+  LimioObject,
+  SubscriptionOffer,
+  AddOn,
+} from "@limio/types";
+import "../styles/index.css";
 
-const TOTAL_COLS = 8
+const TOTAL_COLS = 8;
 
-function formatPrice(rawPrice: { amount: number; currency?: string } | undefined, locale: string): string {
-  return rawPrice?.amount != null ? formatCurrency(rawPrice.amount, rawPrice.currency ?? "USD", locale) : "N/A"
+function formatPrice(
+  rawPrice: { amount: number; currency?: string } | undefined,
+  locale: string,
+): string {
+  return rawPrice?.amount != null
+    ? formatCurrency(rawPrice.amount, rawPrice.currency ?? "USD", locale)
+    : "N/A";
 }
 
 type TableItem = SubscriptionRowData & {
-  key: string
-  rowColor: string
-  chipLabel: string
-  chipColor: string
-}
+  key: string;
+  rowColor: string;
+  chipLabel: string;
+  chipColor: string;
+};
 
 export function SubscriptionDetails({
   subscription,
   currentOffers,
-  currentAddOns
+  currentAddOns,
 }: {
-  subscription: Subscription
-  currentOffers: LimioObject<SubscriptionOffer>[]
-  currentAddOns: AddOn[]
+  subscription: Subscription;
+  currentOffers: LimioObject<SubscriptionOffer>[];
+  currentAddOns: AddOn[];
 }): React.JSX.Element {
-  const locale = getCookie("limio-country")
+  const locale = getCookie("limio-country");
   const {
     offerRowColor,
     offerChipColor,
@@ -40,15 +58,20 @@ export function SubscriptionDetails({
     unitPriceColumnLabel,
     existingQuantityColumnLabel,
     billingPlanColumnLabel,
-    billThroughDateColumnLabel
-  } = useComponentStaticProps()
+    billThroughDateColumnLabel,
+  } = useComponentStaticProps();
 
-  const billThroughDate = getBillThroughDate(subscription.schedule)
+  const billThroughDate = getBillThroughDate(subscription.schedule ?? []);
 
-  const priceFormatter = (rawPrice: { amount: number; currency?: string } | undefined) => formatPrice(rawPrice, locale)
+  const priceFormatter = (
+    rawPrice: { amount: number; currency?: string } | undefined,
+  ) => formatPrice(rawPrice, locale);
 
   const offerItems: TableItem[] = currentOffers.map((offer, i) => {
-    const { displayName, unitPrice, quantity, billingPlan } = mapOfferToRow(offer, priceFormatter)
+    const { displayName, unitPrice, quantity, billingPlan } = mapOfferToRow(
+      offer,
+      priceFormatter,
+    );
     return {
       key: offer.id || `offer-${i}`,
       displayName,
@@ -57,12 +80,15 @@ export function SubscriptionDetails({
       billingPlan,
       rowColor: offerRowColor,
       chipLabel: "Offer",
-      chipColor: offerChipColor
-    }
-  })
+      chipColor: offerChipColor,
+    };
+  });
 
   const addOnItems: TableItem[] = currentAddOns.map((addOn, i) => {
-    const { displayName, unitPrice, quantity, billingPlan } = mapAddOnToRow(addOn, priceFormatter)
+    const { displayName, unitPrice, quantity, billingPlan } = mapAddOnToRow(
+      addOn,
+      priceFormatter,
+    );
     return {
       key: addOn.id || `addon-${i}`,
       displayName,
@@ -71,11 +97,11 @@ export function SubscriptionDetails({
       billingPlan,
       rowColor: addOnRowColor,
       chipLabel: "Add-On",
-      chipColor: addOnChipColor
-    }
-  })
+      chipColor: addOnChipColor,
+    };
+  });
 
-  const tableItems: TableItem[] = offerItems.concat(addOnItems)
+  const tableItems: TableItem[] = offerItems.concat(addOnItems);
 
   return (
     <Box sx={{ width: "100%" }}>
@@ -86,57 +112,96 @@ export function SubscriptionDetails({
           width: "100%",
           tableLayout: "auto",
           "& td": { borderBottom: "none" },
-          borderCollapse: "collapse"
+          borderCollapse: "collapse",
         }}
       >
         <TableBody>
-          {tableItems.map(({ key, displayName, unitPrice, quantity, billingPlan, rowColor, chipLabel, chipColor }, idx) => (
-            <React.Fragment key={key}>
-              <TableRow>
-                <TableCell
-                  colSpan={TOTAL_COLS}
-                  sx={{
-                    backgroundColor: rowColor,
-                    borderBottom: "none",
-                    borderTop: idx > 0 ? "1px solid rgba(0,0,0,0.06)" : "none",
-                    px: 1.5,
-                    py: 0.875
-                  }}
-                >
-                  <Box display="flex" justifyContent="space-between" alignItems="center">
-                    <Typography variant="body2" fontWeight={600} color={primaryTextColor}>
-                      {displayName}
-                    </Typography>
-                    <Chip
-                      label={chipLabel}
-                      size="small"
-                      sx={{
-                        backgroundColor: chipColor,
-                        color: "#fff",
-                        fontWeight: 600,
-                        fontSize: "0.7rem",
-                        height: 20,
-                        borderRadius: "4px"
-                      }}
-                    />
-                  </Box>
-                </TableCell>
-              </TableRow>
+          {tableItems.map(
+            (
+              {
+                key,
+                displayName,
+                unitPrice,
+                quantity,
+                billingPlan,
+                rowColor,
+                chipLabel,
+                chipColor,
+              },
+              idx,
+            ) => (
+              <React.Fragment key={key}>
+                <TableRow>
+                  <TableCell
+                    colSpan={TOTAL_COLS}
+                    sx={{
+                      backgroundColor: rowColor,
+                      borderBottom: "none",
+                      borderTop:
+                        idx > 0 ? "1px solid rgba(0,0,0,0.06)" : "none",
+                      px: 1.5,
+                      py: 0.875,
+                    }}
+                  >
+                    <Box
+                      display="flex"
+                      justifyContent="space-between"
+                      alignItems="center"
+                    >
+                      <Typography
+                        variant="body2"
+                        fontWeight={600}
+                        color={primaryTextColor}
+                      >
+                        {displayName}
+                      </Typography>
+                      <Chip
+                        label={chipLabel}
+                        size="small"
+                        sx={{
+                          backgroundColor: chipColor,
+                          color: "#fff",
+                          fontWeight: 600,
+                          fontSize: "0.7rem",
+                          height: 20,
+                          borderRadius: "4px",
+                        }}
+                      />
+                    </Box>
+                  </TableCell>
+                </TableRow>
 
-              <TableRow sx={{ backgroundColor: "#fff" }}>
-                <TableCell className="cell-base label-cell">{unitPriceColumnLabel}</TableCell>
-                <TableCell className="cell-base value-cell">{unitPrice}</TableCell>
-                <TableCell className="cell-base label-cell">{existingQuantityColumnLabel}</TableCell>
-                <TableCell className="cell-base value-cell">{quantity}</TableCell>
-                <TableCell className="cell-base label-cell">{billingPlanColumnLabel}</TableCell>
-                <TableCell className="cell-base value-cell">{billingPlan}</TableCell>
-                <TableCell className="cell-base label-cell">{billThroughDateColumnLabel}</TableCell>
-                <TableCell className="cell-base value-cell">{billThroughDate}</TableCell>
-              </TableRow>
-            </React.Fragment>
-          ))}
+                <TableRow sx={{ backgroundColor: "#fff" }}>
+                  <TableCell className="cell-base label-cell">
+                    {unitPriceColumnLabel}
+                  </TableCell>
+                  <TableCell className="cell-base value-cell">
+                    {unitPrice}
+                  </TableCell>
+                  <TableCell className="cell-base label-cell">
+                    {existingQuantityColumnLabel}
+                  </TableCell>
+                  <TableCell className="cell-base value-cell">
+                    {quantity}
+                  </TableCell>
+                  <TableCell className="cell-base label-cell">
+                    {billingPlanColumnLabel}
+                  </TableCell>
+                  <TableCell className="cell-base value-cell">
+                    {billingPlan}
+                  </TableCell>
+                  <TableCell className="cell-base label-cell">
+                    {billThroughDateColumnLabel}
+                  </TableCell>
+                  <TableCell className="cell-base value-cell">
+                    {billThroughDate}
+                  </TableCell>
+                </TableRow>
+              </React.Fragment>
+            ),
+          )}
         </TableBody>
       </Table>
     </Box>
-  )
+  );
 }

--- a/components/subscription-summary-table/components/SubscriptionItem.tsx
+++ b/components/subscription-summary-table/components/SubscriptionItem.tsx
@@ -1,0 +1,142 @@
+import * as React from "react"
+import { SubscriptionDetails } from "./SubscriptionDetails"
+import { useComponentStaticProps } from "../componentStaticProps"
+import AutorenewIcon from "@mui/icons-material/Autorenew"
+import ExtensionIcon from "@mui/icons-material/Extension"
+import CancelIcon from "@mui/icons-material/Cancel"
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday"
+import { Box, Stack, Card, CardContent, Divider, Chip, Typography, Button } from "@mui/material"
+import { checkActiveOffersAndAddOns } from "../helpers/OfferDetails"
+import { CancellationNoticeModal } from "./CancellationNoticeModal"
+import { useButtonActions } from "../helpers/ButtonActions"
+import type { Subscription } from "@limio/types"
+import "../styles/index.css"
+
+type SubscriptionItemProps = {
+  subscription: Subscription
+  onToast: (key: string, message: string, variant?: "success" | "error" | "warning" | "info") => void
+}
+
+export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProps): React.JSX.Element {
+  const { showNoticeModal, setShowNoticeModal, cancelError, isNavigating, handleCancelClick, handleUpdateClick, handleEditAddOnsClick } = useButtonActions(
+    subscription,
+    onToast
+  )
+
+  const {
+    subscriptionIdLabel,
+    showCancelButton,
+    cancelButtonText,
+    requestCancellationLink,
+    insufficientNoticeModalTitle,
+    insufficientNoticeModalBody,
+    insufficientNoticeConfirmText,
+    insufficientNoticeCancelText,
+    showCancellationModal,
+    showUpdateButton,
+    updateButtonText,
+    showEditAddOnsButton,
+    editAddOnsButtonText,
+    renewalDateLabel,
+    offerChipColor
+  } = useComponentStaticProps()
+
+  const termEndDate = subscription?.data?.termEndDate || subscription?.termEndDate
+
+  const status = subscription?.status || ""
+
+  const currentOffers = checkActiveOffersAndAddOns(subscription.offers)
+  const currentAddOns = checkActiveOffersAndAddOns(subscription.addOns)
+
+  return (
+    <Card variant="outlined" sx={{ borderRadius: 1, p: 0.75, width: "100%" }}>
+      {/* Card Header */}
+      <Box sx={{ px: 1.5, pt: 1.5, pb: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+        {/* Row 1: Sub ID (left) + chips stacked (far right) */}
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+          <Box>
+            <Typography variant="body2" color="text.secondary">
+              {subscriptionIdLabel}
+            </Typography>
+            <Typography variant="h6" fontWeight={500}>
+              {subscription.name}
+            </Typography>
+          </Box>
+          <Stack direction="column" alignItems="flex-end" spacing={0.5}>
+            <Chip label={status} size="small" className={`status-chip ${status.toLowerCase() === "active" ? "status-chip-active" : "status-chip-cancelled"}`} />
+            {termEndDate && (
+              <Chip
+                icon={<CalendarTodayIcon sx={{ color: "#fff !important", fontSize: "0.7rem" }} />}
+                label={`${renewalDateLabel}: ${new Date(termEndDate).toLocaleDateString()}`}
+                size="small"
+                sx={{
+                  backgroundColor: offerChipColor,
+                  color: "#fff",
+                  fontWeight: 600,
+                  fontSize: "0.8rem",
+                  height: 28,
+                  borderRadius: "4px",
+                  px: 0.5
+                }}
+              />
+            )}
+          </Stack>
+        </Box>
+
+      </Box>
+
+      <Divider sx={{ mx: 1 }} />
+
+      <CardContent
+        sx={{
+          pt: 0.5,
+          "&:last-child": { paddingBottom: "12px" },
+          overflow: "hidden"
+        }}
+      >
+        <SubscriptionDetails subscription={subscription} currentOffers={currentOffers} currentAddOns={currentAddOns} />
+      </CardContent>
+
+      <Divider sx={{ mx: 1 }} />
+
+      {/* Bottom: Action buttons (right-aligned) */}
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end" sx={{ flexWrap: "wrap", px: 1.5, py: 1 }}>
+        {showUpdateButton && (
+          <Button variant="contained" size="small" startIcon={<AutorenewIcon />} onClick={handleUpdateClick} disabled={isNavigating} className="btn-dark">
+            {updateButtonText}
+          </Button>
+        )}
+        {showEditAddOnsButton && (
+          <Button variant="contained" size="small" startIcon={<ExtensionIcon />} onClick={handleEditAddOnsClick} disabled={isNavigating} className="btn-dark">
+            {editAddOnsButtonText}
+          </Button>
+        )}
+        {showCancelButton && (
+          <>
+            <Button variant="outlined" size="small" startIcon={<CancelIcon />} onClick={handleCancelClick} className="btn-cancel">
+              {cancelButtonText}
+            </Button>
+            {cancelError && (
+              <Typography variant="caption" color="error">
+                {cancelError}
+              </Typography>
+            )}
+            {showCancellationModal && (
+              <CancellationNoticeModal
+                open={showNoticeModal}
+                onClose={() => setShowNoticeModal(false)}
+                onConfirmRequest={() => {
+                  window.location.href = `${requestCancellationLink}?subId=${subscription.id}`
+                }}
+                modalTitle={insufficientNoticeModalTitle}
+                modalBody={insufficientNoticeModalBody}
+                confirmButtonText={insufficientNoticeConfirmText}
+                cancelButtonText={insufficientNoticeCancelText}
+              />
+            )}
+          </>
+        )}
+      </Stack>
+    </Card>
+  )
+}

--- a/components/subscription-summary-table/components/SubscriptionItem.tsx
+++ b/components/subscription-summary-table/components/SubscriptionItem.tsx
@@ -1,27 +1,48 @@
-import * as React from "react"
-import { SubscriptionDetails } from "./SubscriptionDetails"
-import { useComponentStaticProps } from "../componentStaticProps"
-import AutorenewIcon from "@mui/icons-material/Autorenew"
-import ExtensionIcon from "@mui/icons-material/Extension"
-import CancelIcon from "@mui/icons-material/Cancel"
-import CalendarTodayIcon from "@mui/icons-material/CalendarToday"
-import { Box, Stack, Card, CardContent, Divider, Chip, Typography, Button } from "@mui/material"
-import { checkActiveOffersAndAddOns } from "../helpers/OfferDetails"
-import { CancellationNoticeModal } from "./CancellationNoticeModal"
-import { useButtonActions } from "../helpers/ButtonActions"
-import type { Subscription } from "@limio/types"
-import "../styles/index.css"
+import * as React from "react";
+import { SubscriptionDetails } from "./SubscriptionDetails";
+import { useComponentStaticProps } from "../componentStaticProps";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
+import ExtensionIcon from "@mui/icons-material/Extension";
+import CancelIcon from "@mui/icons-material/Cancel";
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import {
+  Box,
+  Stack,
+  Card,
+  CardContent,
+  Divider,
+  Chip,
+  Typography,
+  Button,
+} from "@mui/material";
+import { checkActiveOffersAndAddOns } from "../helpers/OfferDetails";
+import { CancellationNoticeModal } from "./CancellationNoticeModal";
+import { useButtonActions } from "../helpers/ButtonActions";
+import type { Subscription } from "@limio/types";
+import "../styles/index.css";
 
 type SubscriptionItemProps = {
-  subscription: Subscription
-  onToast: (key: string, message: string, variant?: "success" | "error" | "warning" | "info") => void
-}
+  subscription: Subscription;
+  onToast: (
+    key: string,
+    message: string,
+    variant?: "success" | "error" | "warning" | "info",
+  ) => void;
+};
 
-export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProps): React.JSX.Element {
-  const { showNoticeModal, setShowNoticeModal, cancelError, isNavigating, handleCancelClick, handleUpdateClick, handleEditAddOnsClick } = useButtonActions(
-    subscription,
-    onToast
-  )
+export function SubscriptionItem({
+  subscription,
+  onToast,
+}: SubscriptionItemProps): React.JSX.Element {
+  const {
+    showNoticeModal,
+    setShowNoticeModal,
+    cancelError,
+    isNavigating,
+    handleCancelClick,
+    handleUpdateClick,
+    handleEditAddOnsClick,
+  } = useButtonActions(subscription, onToast);
 
   const {
     subscriptionIdLabel,
@@ -38,22 +59,38 @@ export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProp
     showEditAddOnsButton,
     editAddOnsButtonText,
     renewalDateLabel,
-    offerChipColor
-  } = useComponentStaticProps()
+    offerChipColor,
+  } = useComponentStaticProps();
 
-  const termEndDate = subscription?.data?.termEndDate || subscription?.termEndDate
+  const termEndDate =
+    subscription?.data?.termEndDate || subscription?.termEndDate;
 
-  const status = subscription?.status || ""
+  const status = subscription?.status || "";
 
-  const currentOffers = checkActiveOffersAndAddOns(subscription.offers)
-  const currentAddOns = checkActiveOffersAndAddOns(subscription.addOns)
+  const currentOffers = checkActiveOffersAndAddOns(subscription.offers);
+  const currentAddOns = checkActiveOffersAndAddOns(subscription.addOns);
 
   return (
     <Card variant="outlined" sx={{ borderRadius: 1, p: 0.75, width: "100%" }}>
       {/* Card Header */}
-      <Box sx={{ px: 1.5, pt: 1.5, pb: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+      <Box
+        sx={{
+          px: 1.5,
+          pt: 1.5,
+          pb: 1,
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+        }}
+      >
         {/* Row 1: Sub ID (left) + chips stacked (far right) */}
-        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+          }}
+        >
           <Box>
             <Typography variant="body2" color="text.secondary">
               {subscriptionIdLabel}
@@ -63,10 +100,18 @@ export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProp
             </Typography>
           </Box>
           <Stack direction="column" alignItems="flex-end" spacing={0.5}>
-            <Chip label={status} size="small" className={`status-chip ${status.toLowerCase() === "active" ? "status-chip-active" : "status-chip-cancelled"}`} />
+            <Chip
+              label={status}
+              size="small"
+              className={`status-chip ${status.toLowerCase() === "active" ? "status-chip-active" : "status-chip-cancelled"}`}
+            />
             {termEndDate && (
               <Chip
-                icon={<CalendarTodayIcon sx={{ color: "#fff !important", fontSize: "0.7rem" }} />}
+                icon={
+                  <CalendarTodayIcon
+                    sx={{ color: "#fff !important", fontSize: "0.7rem" }}
+                  />
+                }
                 label={`${renewalDateLabel}: ${new Date(termEndDate).toLocaleDateString()}`}
                 size="small"
                 sx={{
@@ -76,13 +121,12 @@ export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProp
                   fontSize: "0.8rem",
                   height: 28,
                   borderRadius: "4px",
-                  px: 0.5
+                  px: 0.5,
                 }}
               />
             )}
           </Stack>
         </Box>
-
       </Box>
 
       <Divider sx={{ mx: 1 }} />
@@ -91,29 +135,59 @@ export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProp
         sx={{
           pt: 0.5,
           "&:last-child": { paddingBottom: "12px" },
-          overflow: "hidden"
+          overflow: "hidden",
         }}
       >
-        <SubscriptionDetails subscription={subscription} currentOffers={currentOffers} currentAddOns={currentAddOns} />
+        <SubscriptionDetails
+          subscription={subscription}
+          currentOffers={currentOffers}
+          currentAddOns={currentAddOns}
+        />
       </CardContent>
 
       <Divider sx={{ mx: 1 }} />
 
       {/* Bottom: Action buttons (right-aligned) */}
-      <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end" sx={{ flexWrap: "wrap", px: 1.5, py: 1 }}>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        justifyContent="flex-end"
+        sx={{ flexWrap: "wrap", px: 1.5, py: 1 }}
+      >
         {showUpdateButton && (
-          <Button variant="contained" size="small" startIcon={<AutorenewIcon />} onClick={handleUpdateClick} disabled={isNavigating} className="btn-dark">
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AutorenewIcon />}
+            onClick={handleUpdateClick}
+            disabled={isNavigating}
+            className="btn-dark"
+          >
             {updateButtonText}
           </Button>
         )}
         {showEditAddOnsButton && (
-          <Button variant="contained" size="small" startIcon={<ExtensionIcon />} onClick={handleEditAddOnsClick} disabled={isNavigating} className="btn-dark">
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<ExtensionIcon />}
+            onClick={handleEditAddOnsClick}
+            disabled={isNavigating}
+            className="btn-dark"
+          >
             {editAddOnsButtonText}
           </Button>
         )}
         {showCancelButton && (
           <>
-            <Button variant="outlined" size="small" startIcon={<CancelIcon />} onClick={handleCancelClick} className="btn-cancel">
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<CancelIcon />}
+              onClick={handleCancelClick}
+              className="btn-cancel"
+            >
               {cancelButtonText}
             </Button>
             {cancelError && (
@@ -126,7 +200,7 @@ export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProp
                 open={showNoticeModal}
                 onClose={() => setShowNoticeModal(false)}
                 onConfirmRequest={() => {
-                  window.location.href = `${requestCancellationLink}?subId=${subscription.id}`
+                  window.location.href = `${requestCancellationLink}?subId=${encodeURIComponent(subscription.id)}`;
                 }}
                 modalTitle={insufficientNoticeModalTitle}
                 modalBody={insufficientNoticeModalBody}
@@ -138,5 +212,5 @@ export function SubscriptionItem({ subscription, onToast }: SubscriptionItemProp
         )}
       </Stack>
     </Card>
-  )
+  );
 }

--- a/components/subscription-summary-table/components/Subscriptions.tsx
+++ b/components/subscription-summary-table/components/Subscriptions.tsx
@@ -1,0 +1,78 @@
+import React from "react"
+import { useState } from "react"
+import { SubscriptionItem } from "./SubscriptionItem"
+import { useComponentStaticProps } from "../componentStaticProps"
+import { Box, Typography, Stack, Chip, TextField, MenuItem, Button, Skeleton } from "@mui/material"
+import TableRowsIcon from "@mui/icons-material/TableRows"
+import AddIcon from "@mui/icons-material/Add"
+import type { Subscription } from "@limio/types"
+import "../styles/index.css"
+
+type SubscriptionsProps = {
+  subscriptions: Subscription[]
+  onToast: (key: string, message: string, variant?: "success" | "error" | "warning" | "info") => void
+}
+
+export function Subscriptions({ subscriptions, onToast }: SubscriptionsProps) {
+  const [statusFilter, setStatusFilter] = useState("all")
+
+  const { pageTitle, pageSubtitle, showAddNewSubscriptionButton, addNewSubscriptionButtonText, addNewSubscriptionLink } = useComponentStaticProps()
+
+  const filteredSubscriptions =
+    subscriptions?.filter((sub) => {
+      if (statusFilter === "all") return true
+      return sub?.status?.toLowerCase() === statusFilter
+    }) ?? []
+
+  return (
+    <Box>
+      {/* Page Header */}
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" mb={3}>
+        <Box>
+          <Stack direction="row" alignItems="center" spacing={1} mb={0.5}>
+            <TableRowsIcon sx={{ color: "#2D3135" }} />
+            <Typography variant="h4" fontWeight={600} color="#2D3135">
+              {pageTitle}
+            </Typography>
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            {pageSubtitle}
+          </Typography>
+        </Box>
+
+        {/* Add New Subscription button */}
+        {showAddNewSubscriptionButton && (
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            className="btn-dark"
+            onClick={() => {
+              window.location.href = addNewSubscriptionLink
+            }}
+          >
+            {addNewSubscriptionButtonText}
+          </Button>
+        )}
+      </Stack>
+
+      {/* Filter Bar */}
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2} mb={3} alignItems="center">
+        <Chip label={`Total Subscriptions: ${subscriptions?.length ?? 0}`} color="default" />
+        <TextField size="small" select label="Status" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} sx={{ minWidth: 140 }}>
+          <MenuItem value="all">All</MenuItem>
+          <MenuItem value="active">Active</MenuItem>
+          <MenuItem value="cancelled">Cancelled</MenuItem>
+        </TextField>
+      </Stack>
+
+      {/* Subscription Cards */}
+      <Stack spacing={2}>
+        {filteredSubscriptions.map((subscription) => (
+          <SubscriptionItem key={subscription.id} subscription={subscription} onToast={onToast} />
+        ))}
+      </Stack>
+    </Box>
+  )
+}
+
+Subscriptions.Skeleton = () => <Skeleton variant="rounded" width="100%" height={232} />

--- a/components/subscription-summary-table/helpers/ButtonActions.ts
+++ b/components/subscription-summary-table/helpers/ButtonActions.ts
@@ -24,8 +24,8 @@ export function useButtonActions(subscription: Subscription, onToast: OnToast) {
 
         if (noticeDays > minimumDaysNotice) {
           const cancelUrl = new URL(cancelButtonLink, window.location.origin)
-          cancelUrl.searchParams.set("subId", String(subscription.id))
-          window.location.href = cancelUrl.toString()
+        if (noticeDays >= minimumDaysNotice) {
+          window.location.href = `${cancelButtonLink}?subId=${subscription.id}`
         } else {
           setShowNoticeModal(true)
         }

--- a/components/subscription-summary-table/helpers/ButtonActions.ts
+++ b/components/subscription-summary-table/helpers/ButtonActions.ts
@@ -1,0 +1,73 @@
+import { useState } from "react"
+import { useBasket } from "@limio/sdk"
+import { useComponentStaticProps } from "../componentStaticProps"
+import { getDaysNoticeGiven } from "./CancellationDate"
+import type { Subscription } from "@limio/types"
+
+type OnToast = (key: string, message: string, variant?: "success" | "error" | "warning" | "info") => void
+
+export function useButtonActions(subscription: Subscription, onToast: OnToast) {
+  const [showNoticeModal, setShowNoticeModal] = useState(false)
+  const [cancelError, setCancelError] = useState<string | null>(null)
+  const [isNavigating, setIsNavigating] = useState(false)
+
+  const { cancelButtonLink, minimumDaysNotice, cancellationErrorMessage, showCancellationModal, updateButtonLink, editAddOnsLink } =
+    useComponentStaticProps()
+
+  const { initiateCheckout } = useBasket()
+
+  const handleCancelClick = () => {
+    if (showCancellationModal) {
+      try {
+        setCancelError(null)
+        const noticeDays = getDaysNoticeGiven(subscription)
+
+        if (noticeDays > minimumDaysNotice) {
+          window.location.href = `${cancelButtonLink}?subId=${subscription.id}`
+        } else {
+          setShowNoticeModal(true)
+        }
+      } catch (error) {
+        console.error("Cancellation check failed:", error)
+        setCancelError(cancellationErrorMessage)
+      }
+    } else {
+      window.location.href = `${cancelButtonLink}?subId=${subscription.id}`
+    }
+  }
+
+  const handleCheckoutNavigation = async (destinationLink: string, errorToastKey: string, errorLogMessage: string) => {
+    setIsNavigating(true)
+    try {
+      const basket = await initiateCheckout({
+        order: {
+          order_type: "update_subscription",
+          forSubscription: { id: subscription.id }
+        }
+      })
+      const checkoutId = basket?.order?.checkoutId
+      if (checkoutId) {
+        window.location.href = `${destinationLink}?basket=${checkoutId}`
+      }
+    } catch (error) {
+      console.error(errorLogMessage, error)
+      onToast(errorToastKey, "Something went wrong. Please try again.", "error")
+    } finally {
+      setIsNavigating(false)
+    }
+  }
+
+  const handleUpdateClick = () => handleCheckoutNavigation(updateButtonLink, "updateError", "Update subscription failed:")
+
+  const handleEditAddOnsClick = () => handleCheckoutNavigation(editAddOnsLink, "editAddOnsError", "Edit add-ons checkout failed:")
+
+  return {
+    showNoticeModal,
+    setShowNoticeModal,
+    cancelError,
+    isNavigating,
+    handleCancelClick,
+    handleUpdateClick,
+    handleEditAddOnsClick
+  }
+}

--- a/components/subscription-summary-table/helpers/ButtonActions.ts
+++ b/components/subscription-summary-table/helpers/ButtonActions.ts
@@ -23,7 +23,9 @@ export function useButtonActions(subscription: Subscription, onToast: OnToast) {
         const noticeDays = getDaysNoticeGiven(subscription)
 
         if (noticeDays > minimumDaysNotice) {
-          window.location.href = `${cancelButtonLink}?subId=${subscription.id}`
+          const cancelUrl = new URL(cancelButtonLink, window.location.origin)
+          cancelUrl.searchParams.set("subId", String(subscription.id))
+          window.location.href = cancelUrl.toString()
         } else {
           setShowNoticeModal(true)
         }
@@ -32,7 +34,9 @@ export function useButtonActions(subscription: Subscription, onToast: OnToast) {
         setCancelError(cancellationErrorMessage)
       }
     } else {
-      window.location.href = `${cancelButtonLink}?subId=${subscription.id}`
+      const cancelUrl = new URL(cancelButtonLink, window.location.origin)
+      cancelUrl.searchParams.set("subId", String(subscription.id))
+      window.location.href = cancelUrl.toString()
     }
   }
 
@@ -48,6 +52,9 @@ export function useButtonActions(subscription: Subscription, onToast: OnToast) {
       const checkoutId = basket?.order?.checkoutId
       if (checkoutId) {
         window.location.href = `${destinationLink}?basket=${checkoutId}`
+      } else {
+        console.error(errorLogMessage, "No checkoutId returned from initiateCheckout", basket)
+        onToast(errorToastKey, "Something went wrong. Please try again.", "error")
       }
     } catch (error) {
       console.error(errorLogMessage, error)

--- a/components/subscription-summary-table/helpers/CancellationDate.ts
+++ b/components/subscription-summary-table/helpers/CancellationDate.ts
@@ -1,0 +1,14 @@
+import type { Subscription } from "@limio/types"
+
+export function calculateDaysUntilDate(futureDate: Date): number {
+  const diffMs = futureDate.getTime() - Date.now()
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+}
+
+export function getDaysNoticeGiven(subscription: Subscription): number {
+  const termEndDate = subscription.data?.termEndDate
+  if (!termEndDate) {
+    throw new Error("No term end date found for subscription")
+  }
+  return calculateDaysUntilDate(new Date(termEndDate))
+}

--- a/components/subscription-summary-table/helpers/CancellationDate.ts
+++ b/components/subscription-summary-table/helpers/CancellationDate.ts
@@ -6,9 +6,13 @@ export function calculateDaysUntilDate(futureDate: Date): number {
 }
 
 export function getDaysNoticeGiven(subscription: Subscription): number {
-  const termEndDate = subscription.data?.termEndDate
+  const termEndDate = subscription.data?.termEndDate || subscription?.termEndDate
   if (!termEndDate) {
     throw new Error("No term end date found for subscription")
   }
-  return calculateDaysUntilDate(new Date(termEndDate))
+  const date = new Date(termEndDate)
+  if (isNaN(date.getTime())) {
+    throw new Error(`Invalid termEndDate: ${termEndDate}`)
+  }
+  return calculateDaysUntilDate(date)
 }

--- a/components/subscription-summary-table/helpers/ErrorMessage.tsx
+++ b/components/subscription-summary-table/helpers/ErrorMessage.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { sanitiseHTML } from "@limio/sdk"
+
+type ErrorMessageProps = {
+  text?: string
+  icon?: React.ReactNode
+}
+
+export function ErrorMessage({ icon, text }: ErrorMessageProps): React.JSX.Element {
+  return (
+    <div style={{ textAlign: "center", paddingTop: "20px", paddingBottom: "20px" }}>
+      {icon}
+      <div dangerouslySetInnerHTML={{ __html: sanitiseHTML(text) }} />
+    </div>
+  )
+}

--- a/components/subscription-summary-table/helpers/OfferDetails.ts
+++ b/components/subscription-summary-table/helpers/OfferDetails.ts
@@ -1,4 +1,3 @@
-import { DateTime } from "@limio/date"
 import type { LimioObject, SubscriptionOffer, AddOn } from "@limio/types"
 import { getOfferBillingLabel, getAddOnBillingLabel } from "./Schedule"
 
@@ -35,9 +34,9 @@ export function mapAddOnToRow(addOn: AddOn, formatPrice: FormatPrice): Subscript
 type WithDateRange = { data: { start: string; end?: string } }
 
 export function checkActiveOffersAndAddOns<T extends WithDateRange>(items: T[] = []): T[] {
-  const currentDate = DateTime.utc().toISO()
+  const currentDate = new Date().toISOString()
   return items
     .sort((a, b) => new Date(a.data.start).getTime() - new Date(b.data.start).getTime())
-    .filter((item) => !item.data?.end || DateTime.fromISO(item.data.end).toString() >= currentDate)
+    .filter((item) => !item.data?.end || item.data.end >= currentDate)
     .filter((item) => item.data.start <= currentDate) // Item might be future dated for next term etc.
 }

--- a/components/subscription-summary-table/helpers/OfferDetails.ts
+++ b/components/subscription-summary-table/helpers/OfferDetails.ts
@@ -1,0 +1,43 @@
+import { DateTime } from "@limio/date"
+import type { LimioObject, SubscriptionOffer, AddOn } from "@limio/types"
+import { getOfferBillingLabel, getAddOnBillingLabel } from "./Schedule"
+
+export type SubscriptionRowData = {
+  displayName: string
+  billingPlan: string
+  quantity: number
+  unitPrice: string
+}
+
+type FormatPrice = (rawPrice: { amount: number; currency?: string } | undefined) => string
+
+export function mapOfferToRow(subscriptionOffer: LimioObject<SubscriptionOffer>, formatPrice: FormatPrice): SubscriptionRowData {
+  const offer = subscriptionOffer?.data?.offer
+  const displayName = offer?.data?.attributes?.display_name__limio || offer?.data?.productBundles?.[0]?.rate_plan || offer?.name || "N/A"
+  return {
+    displayName,
+    billingPlan: getOfferBillingLabel(offer),
+    quantity: subscriptionOffer?.data?.quantity ?? 0,
+    unitPrice: formatPrice(subscriptionOffer?.data?.price)
+  }
+}
+
+export function mapAddOnToRow(addOn: AddOn, formatPrice: FormatPrice): SubscriptionRowData {
+  const displayName = addOn?.data?.offer?.data?.products?.[0]?.attributes?.display_name__limio || addOn?.data?.offer?.name || "N/A"
+  return {
+    displayName,
+    billingPlan: getAddOnBillingLabel(addOn?.data?.offer),
+    quantity: addOn?.data?.quantity ?? 1,
+    unitPrice: formatPrice(addOn?.data?.price)
+  }
+}
+
+type WithDateRange = { data: { start: string; end?: string } }
+
+export function checkActiveOffersAndAddOns<T extends WithDateRange>(items: T[] = []): T[] {
+  const currentDate = DateTime.utc().toISO()
+  return items
+    .sort((a, b) => new Date(a.data.start).getTime() - new Date(b.data.start).getTime())
+    .filter((item) => !item.data?.end || DateTime.fromISO(item.data.end).toString() >= currentDate)
+    .filter((item) => item.data.start <= currentDate) // Item might be future dated for next term etc.
+}

--- a/components/subscription-summary-table/helpers/Schedule.ts
+++ b/components/subscription-summary-table/helpers/Schedule.ts
@@ -1,0 +1,36 @@
+import { DateTime } from "@limio/date"
+import type { Schedule } from "@limio/types"
+import type { ElasticOffer } from "@limio/types"
+
+
+function formatBillingLabel(interval = 1, unit = "months") {
+  const base = unit.toLowerCase().replace(/s$/, "")
+  const capitalized = base.charAt(0).toUpperCase() + base.slice(1)
+  const unitLabel = interval === 1 ? capitalized : `${capitalized}s`
+  return `${interval}-${unitLabel}`
+}
+
+export function getOfferBillingLabel(offer: ElasticOffer): string {
+  const term = offer?.data?.attributes?.term__limio
+  if (!term) return "N/A"
+
+  const { length = 1, type = "months" } = term
+  return formatBillingLabel(length, type)
+}
+
+export function getAddOnBillingLabel(offer: ElasticOffer): string {
+  const term = offer?.data?.attributes?.price__limio?.[0]
+  if (!term) return "N/A"
+
+  const { repeat_interval = 1, repeat_interval_type = "months" } = term
+  return formatBillingLabel(repeat_interval, repeat_interval_type)
+}
+
+export function getBillThroughDate(schedules: Schedule[]): string {
+  const currentDate = DateTime.utc().toISO()
+  const nextBillingSchedule = schedules
+    .filter(s => ["active", "pending", "pending-external"].includes(s.status))
+    .sort((a, b) => new Date(a.data.date).getTime() - new Date(b.data.date).getTime())
+    .find(s => s.data.date > currentDate)
+  return nextBillingSchedule?.data?.date ? new Date(nextBillingSchedule.data.date).toLocaleDateString() : "N/A"
+}

--- a/components/subscription-summary-table/helpers/Schedule.ts
+++ b/components/subscription-summary-table/helpers/Schedule.ts
@@ -28,7 +28,7 @@ export function getAddOnBillingLabel(offer: ElasticOffer): string {
 
 export function getBillThroughDate(schedules: Schedule[]): string {
   const currentDate = DateTime.utc().toISO()
-  const nextBillingSchedule = schedules
+  const nextBillingSchedule = (schedules ?? [])
     .filter(s => ["active", "pending", "pending-external"].includes(s.status))
     .sort((a, b) => new Date(a.data.date).getTime() - new Date(b.data.date).getTime())
     .find(s => s.data.date > currentDate)

--- a/components/subscription-summary-table/index.ts
+++ b/components/subscription-summary-table/index.ts
@@ -1,0 +1,2 @@
+import SubscriptionSummaryTable from "./SubscriptionSummaryTable";
+export default SubscriptionSummaryTable

--- a/components/subscription-summary-table/package.json
+++ b/components/subscription-summary-table/package.json
@@ -1,0 +1,238 @@
+{
+  "name": "component-subscription-summary-table",
+  "version": "1.0.0",
+  "description": "",
+  "main": "./index.ts",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
+    "@mui/icons-material": "^5.17.1",
+    "@mui/material": "^5.17.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.27"
+  },
+  "peerDependencies": {
+    "@sentry/browser": "*",
+    "react": "*",
+    "react-dom": "*"
+  },
+  "limioProps": [
+    {
+      "id": "notFoundText__limio_richtext",
+      "label": "Subscriptions not found text",
+      "type": "richtext",
+      "default": "Sorry! We couldn't find any subscription information linked to your account. Please contact our support team for more information."
+    },
+    {
+      "id": "componentId",
+      "label": "Component Id",
+      "type": "string",
+      "default": "subscriptions-summary-limio"
+    },
+    {
+      "id": "subscriptionIdLabel",
+      "label": "Label text for subscription ID",
+      "type": "string",
+      "default": "Subscription ID"
+    },
+    {
+      "id": "showCancelButton",
+      "label": "Show or hide cancel button",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "cancelButtonText",
+      "label": "Cancel button text",
+      "type": "string",
+      "default": "Cancel"
+    },
+    {
+      "id": "cancelButtonLink",
+      "label": "Link to cancel page",
+      "type": "string",
+      "default": "/"
+    },
+    {
+      "id": "minimumDaysNotice",
+      "label": "Minimum days notice required for cancellation",
+      "type": "number",
+      "default": 60
+    },
+    {
+      "id": "requestCancellationLink",
+      "label": "Link to cancellation request form (insufficient notice)",
+      "type": "string",
+      "default": "/request-cancellation"
+    },
+    {
+      "id": "insufficientNoticeModalTitle",
+      "label": "Modal title for insufficient notice",
+      "type": "string",
+      "default": "Cancellation Notice Period"
+    },
+    {
+      "id": "insufficientNoticeModalBody",
+      "label": "Modal body text for insufficient notice",
+      "type": "string",
+      "default": "Your notice period is less than the required minimum. You can submit a cancellation request that will take effect at the next billing cycle."
+    },
+    {
+      "id": "insufficientNoticeConfirmText",
+      "label": "Modal confirm button text",
+      "type": "string",
+      "default": "Submit Request"
+    },
+    {
+      "id": "insufficientNoticeCancelText",
+      "label": "Modal cancel button text",
+      "type": "string",
+      "default": "Go Back"
+    },
+    {
+      "id": "cancellationErrorMessage",
+      "label": "Error message when cancellation check fails",
+      "type": "string",
+      "default": "Unable to process your request. Please contact support."
+    },
+    {
+      "id": "showUpdateButton",
+      "label": "Show or hide update button",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "showCancellationModal",
+      "label": "Show or hide cancellation modal",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "updateButtonText",
+      "label": "Update button text",
+      "type": "string",
+      "default": "Renew"
+    },
+    {
+      "id": "updateButtonLink",
+      "label": "Link to update page",
+      "type": "string",
+      "default": "/"
+    },
+    {
+      "id": "pageTitle",
+      "label": "Page title",
+      "type": "string",
+      "default": "Subscriptions"
+    },
+    {
+      "id": "pageSubtitle",
+      "label": "Page subtitle",
+      "type": "string",
+      "default": "View and manage active subscriptions."
+    },
+    {
+      "id": "billingPlanColumnLabel",
+      "label": "Billing Plan column header",
+      "type": "string",
+      "default": "Billing Plan"
+    },
+    {
+      "id": "unitPriceColumnLabel",
+      "label": "Unit Price column header",
+      "type": "string",
+      "default": "Unit Price"
+    },
+    {
+      "id": "existingQuantityColumnLabel",
+      "label": "Existing Quantity column header",
+      "type": "string",
+      "default": "Existing Quantity"
+    },
+    {
+      "id": "billThroughDateColumnLabel",
+      "label": "Bill Through Date column header",
+      "type": "string",
+      "default": "Bill Through Date"
+    },
+    {
+      "id": "showEditAddOnsButton",
+      "label": "Show Edit Add-Ons button",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "editAddOnsButtonText",
+      "label": "Edit Add-Ons button text",
+      "type": "string",
+      "default": "Edit Add-Ons"
+    },
+    {
+      "id": "editAddOnsLink",
+      "label": "Link for Edit Add-Ons page",
+      "type": "string",
+      "default": "/"
+    },
+    {
+      "id": "showAddNewSubscriptionButton",
+      "label": "Show Add New Subscription button",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "addNewSubscriptionButtonText",
+      "label": "Add New Subscription button text",
+      "type": "string",
+      "default": "Add New Subscription"
+    },
+    {
+      "id": "addNewSubscriptionLink",
+      "label": "Link for Add New Subscription page",
+      "type": "string",
+      "default": "/"
+    },
+    {
+      "id": "offerRowColor",
+      "label": "Offer row background colour",
+      "type": "color",
+      "default": "#FEF0EA"
+    },
+    {
+      "id": "offerChipColor",
+      "label": "Offer chip colour",
+      "type": "color",
+      "default": "#F05A28"
+    },
+    {
+      "id": "addOnRowColor",
+      "label": "Add-on row background colour",
+      "type": "color",
+      "default": "#F1F2F3"
+    },
+    {
+      "id": "addOnChipColor",
+      "label": "Add-on chip colour",
+      "type": "color",
+      "default": "#4E545F"
+    },
+    {
+      "id": "primaryTextColor",
+      "label": "Primary text colour",
+      "type": "color",
+      "default": "#2D3135"
+    },
+    {
+      "id": "renewalDateLabel",
+      "label": "Renewal date chip label",
+      "type": "string",
+      "default": "Renewal Date"
+    }
+  ]
+}

--- a/components/subscription-summary-table/styles/index.css
+++ b/components/subscription-summary-table/styles/index.css
@@ -1,0 +1,96 @@
+.subscription-details-table td.cell-base {
+  font-size: 0.825rem;
+  border-bottom: none;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.subscription-details-table td.label-cell {
+  color: #6c757d;
+  font-weight: 500;
+  width: 15%;
+  white-space: nowrap;
+}
+
+.subscription-details-table td.label-cell-wide {
+  color: #6c757d;
+  font-weight: 500;
+  width: 40%;
+}
+
+.subscription-details-table td.value-cell {
+  color: #2d3135;
+  font-weight: 600;
+  width: 15%;
+}
+
+/* ── Buttons ─────────────────────────────────── */
+
+.subscription-summary .btn-dark {
+  background-color: #1a1a1a;
+  color: #fff;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.subscription-summary .btn-dark:hover {
+  background-color: var(--accent-color, #F05A28);
+}
+
+.subscription-summary .btn-cancel {
+  color: #6c757d;
+  border-color: #6c757d;
+}
+
+.subscription-summary .btn-cancel:hover {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+/* ── Status chip ─────────────────────────────── */
+
+.subscription-summary .status-chip {
+  text-transform: capitalize;
+  font-weight: 500;
+  border-radius: 4px;
+}
+
+.subscription-summary .status-chip-active {
+  color: #106617;
+  background-color: #e9feeb;
+}
+
+.subscription-summary .status-chip-cancelled {
+  color: #591414;
+  background-color: #fbeaea;
+}
+
+/* ── Cancellation notice modal ───────────────── */
+
+.subscription-modal .modal-title {
+  color: #2d3135;
+  font-weight: 600;
+}
+
+.subscription-modal .modal-actions {
+  padding: 16px 24px;
+}
+
+.subscription-modal .modal-btn-cancel {
+  color: #6c757d;
+  border-color: #6c757d;
+}
+
+.subscription-modal .modal-btn-cancel:hover {
+  background-color: #f5f5f5;
+}
+
+.subscription-modal .modal-btn-confirm {
+  background-color: var(--accent-color, #F05A28);
+  color: #fff;
+}
+
+.subscription-modal .modal-btn-confirm:hover {
+  filter: brightness(0.85);
+}

--- a/components/subscription-summary-table/styles/index.css
+++ b/components/subscription-summary-table/styles/index.css
@@ -34,7 +34,7 @@
 }
 
 .subscription-summary .btn-dark:hover {
-  background-color: var(--accent-color, #F05A28);
+  background-color: var(--accent-color-dark, #d24a1f);
 }
 
 .subscription-summary .btn-cancel {
@@ -87,7 +87,7 @@
 }
 
 .subscription-modal .modal-btn-confirm {
-  background-color: var(--accent-color, #F05A28);
+  background-color: var(--accent-color-dark, #d24a1f);
   color: #fff;
 }
 


### PR DESCRIPTION
Add a new `subscription-summary-table` component. The component is based on the `order-table-material` with mostly UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New subscription summary UI with per-subscription details, active offers/add‑ons, pricing, billing labels and bill‑through dates
  * Filtering (status and URL-param driven), Skeleton loading state, error message view, and toast notifications
  * Row actions: Update, Edit Add‑Ons, Cancel with confirmation modal and cancel notice handling
* **Style**
  * Comprehensive CSS for table, chips, buttons and modal
* **Chores**
  * Component config and public entry added for customization and packaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->