### PR TITLE
Add Maltego Data Capture Form component

### DIFF
--- a/component-playground/.storybook/main.js
+++ b/component-playground/.storybook/main.js
@@ -10,7 +10,7 @@ function getAbsolutePath(value) {
 
 /** @type { import('@storybook/react-webpack5').StorybookConfig } */
 const config = {
-    stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+    stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)", "../../components/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
     addons: [
         getAbsolutePath("@storybook/addon-webpack5-compiler-swc"),
         getAbsolutePath("@storybook/addon-onboarding"),

--- a/component-playground/packages/limio/shop/src/shop/helpers/postRequests.js
+++ b/component-playground/packages/limio/shop/src/shop/helpers/postRequests.js
@@ -1,0 +1,4 @@
+export async function sendOrder(order) {
+  console.log("[Mock] sendOrder called with:", order)
+  return new Promise(resolve => setTimeout(() => resolve({ success: true }), 1000))
+}

--- a/components/maltego-data-capture-form/MaltegoDataCaptureForm.stories.jsx
+++ b/components/maltego-data-capture-form/MaltegoDataCaptureForm.stories.jsx
@@ -1,0 +1,113 @@
+import React from "react"
+import MaltegoDataCaptureForm from "./index"
+import { __mockConfig } from "@limio/sdk"
+
+export default {
+  title: "Components/MaltegoDataCaptureForm",
+  component: MaltegoDataCaptureForm,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    redirectUrl: {
+      control: { type: "text" },
+      name: "Redirect URL",
+    },
+    submitLabel: {
+      control: { type: "text" },
+      name: "Submit Button Label",
+    },
+  },
+  args: {
+    redirectUrl: "",
+    submitLabel: "Submit",
+  },
+}
+
+const SampleFields = () => (
+  <>
+    <div style={{ marginBottom: "16px" }}>
+      <label htmlFor="email" style={{ display: "block", fontSize: "14px", fontWeight: 600, marginBottom: "4px", color: "#333" }}>
+        Email Address <span style={{ color: "#dc3545" }}>*</span>
+      </label>
+      <input type="email" id="email" name="email" required placeholder="you@company.com" />
+    </div>
+    <div style={{ marginBottom: "16px" }}>
+      <label htmlFor="orgType" style={{ display: "block", fontSize: "14px", fontWeight: 600, marginBottom: "4px", color: "#333" }}>
+        Organisation Type <span style={{ color: "#dc3545" }}>*</span>
+      </label>
+      <select id="orgType" name="orgType" required>
+        <option value="">Select...</option>
+        <option value="law_enforcement">Law Enforcement</option>
+        <option value="government">Government Agency</option>
+        <option value="enterprise">Enterprise</option>
+        <option value="education">Education / Research</option>
+        <option value="other">Other</option>
+      </select>
+    </div>
+    <div style={{ marginBottom: "16px" }}>
+      <label htmlFor="country" style={{ display: "block", fontSize: "14px", fontWeight: 600, marginBottom: "4px", color: "#333" }}>
+        Country <span style={{ color: "#dc3545" }}>*</span>
+      </label>
+      <input type="text" id="country" name="country" required placeholder="e.g. Germany" />
+    </div>
+    <div style={{ marginBottom: "16px" }}>
+      <label htmlFor="companyName" style={{ display: "block", fontSize: "14px", fontWeight: 600, marginBottom: "4px", color: "#333" }}>
+        Company Name
+      </label>
+      <input type="text" id="companyName" name="companyName" placeholder="Your company name" />
+    </div>
+  </>
+)
+
+const Template = (args) => {
+  __mockConfig.propsOverride = {
+    requiredLabel: "Required",
+    optionalLabel: "",
+    submitLabel: args.submitLabel,
+    "successFormMessage__limio_richtext": "Thank you for submitting your information.",
+    "invalidFormMessage__limio_richtext": "Your information could not be submitted. Please check your answers and try again.",
+    redirectUrl: args.redirectUrl,
+  }
+  return (
+    <MaltegoDataCaptureForm>
+      <SampleFields />
+    </MaltegoDataCaptureForm>
+  )
+}
+
+export const Default = {
+  name: "Default (No Redirect)",
+  render: Template,
+}
+
+export const WithRedirect = {
+  name: "With Redirect URL",
+  args: {
+    redirectUrl: "/checkout",
+    submitLabel: "Continue to Checkout",
+  },
+  render: Template,
+}
+
+export const CustomMessages = {
+  name: "Custom Messages & Colors",
+  render: (args) => {
+    __mockConfig.propsOverride = {
+      requiredLabel: "Required",
+      submitLabel: "Send",
+      "successFormMessage__limio_richtext": "<strong>Success!</strong> Your vetting information has been received.",
+      "successFormMessageFontColor__limio_color": "#155724",
+      "successFormMessageBackgroundColor__limio_color": "#d4edda",
+      "invalidFormMessage__limio_richtext": "<strong>Error:</strong> Please check the form fields and try again.",
+      "invalidFormMessageFontColor__limio_color": "#721c24",
+      "invalidFormMessageBackgroundColor__limio_color": "#f8d7da",
+      redirectUrl: "",
+    }
+    return (
+      <MaltegoDataCaptureForm>
+        <SampleFields />
+      </MaltegoDataCaptureForm>
+    )
+  },
+}

--- a/components/maltego-data-capture-form/componentStaticProps.js
+++ b/components/maltego-data-capture-form/componentStaticProps.js
@@ -1,0 +1,8 @@
+import packageData from "./package.json"
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+
+export function useStaticProps() {
+  const defaultComponentProps = getPropsFromPackageJson(packageData)
+  const componentProps = useComponentProps(defaultComponentProps)
+  return componentProps
+}

--- a/components/maltego-data-capture-form/index.css
+++ b/components/maltego-data-capture-form/index.css
@@ -1,0 +1,148 @@
+.dcf-container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.dcf-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dcf-form.dcf-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.dcf-required-label {
+  font-size: 14px;
+  color: #666;
+  margin: 0 0 8px 0;
+}
+
+.dcf-asterisk {
+  color: #dc3545;
+  font-weight: bold;
+}
+
+.dcf-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dcf-fields input,
+.dcf-fields select,
+.dcf-fields textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 16px;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+
+.dcf-fields input:focus,
+.dcf-fields select:focus,
+.dcf-fields textarea:focus {
+  outline: none;
+  border-color: #0066cc;
+  box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.2);
+}
+
+.dcf-fields textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.dcf-fields label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: #333;
+}
+
+/* Messages */
+.dcf-message {
+  padding: 12px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.dcf-message-success {
+  color: #155724;
+  background-color: #d4edda;
+  border: 1px solid #c3e6cb;
+}
+
+.dcf-message-error {
+  color: #856404;
+  background-color: #fff3cd;
+  border: 1px solid #ffeeba;
+}
+
+/* Field-level errors */
+.dcf-field-errors {
+  padding: 8px 12px;
+  background-color: #fff3cd;
+  border: 1px solid #ffeeba;
+  border-radius: 4px;
+}
+
+.dcf-field-error {
+  color: #dc3545;
+  font-size: 13px;
+  margin: 4px 0;
+}
+
+/* Submit button */
+.dcf-submit-container {
+  margin-top: 8px;
+}
+
+.dcf-submit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 120px;
+  padding: 12px 24px;
+  background-color: #0066cc;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.dcf-submit-button:hover:not(:disabled) {
+  background-color: #0052a3;
+}
+
+.dcf-submit-button:disabled {
+  background-color: #999;
+  cursor: not-allowed;
+}
+
+/* Loading spinner */
+.dcf-spinner {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: dcf-spin 0.6s linear infinite;
+}
+
+@keyframes dcf-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/components/maltego-data-capture-form/index.js
+++ b/components/maltego-data-capture-form/index.js
@@ -1,0 +1,202 @@
+// @flow
+import * as React from "react"
+import { v4 as uuid } from "uuid"
+import { sendOrder } from "@limio/shop/src/shop/helpers/postRequests.js"
+import { useStaticProps } from "./componentStaticProps"
+import "./index.css"
+
+type FormState = "idle" | "submitting" | "success" | "error"
+
+function MaltegoDataCaptureForm({ children }): React.Node {
+  const props = useStaticProps() || {}
+  const {
+    requiredLabel,
+    optionalLabel,
+    submitLabel,
+    "successFormMessage__limio_richtext": successFormMessage,
+    "successFormMessageFontColor__limio_color": successFontColor,
+    "successFormMessageBackgroundColor__limio_color": successBgColor,
+    "invalidFormMessage__limio_richtext": invalidFormMessage,
+    "invalidFormMessageFontColor__limio_color": invalidFontColor,
+    "invalidFormMessageBackgroundColor__limio_color": invalidBgColor,
+    redirectUrl,
+  } = props
+  const formRef = React.useRef(null)
+  const [formState, setFormState] = React.useState<FormState>("idle")
+  const [errors, setErrors] = React.useState<{ [string]: string }>({})
+
+  const isDisabled = formState === "submitting" || formState === "success"
+
+  const collectFormData = (): Object => {
+    const formData = {}
+    if (!formRef.current) return formData
+
+    const inputs = formRef.current.querySelectorAll("input, select, textarea")
+    inputs.forEach(input => {
+      const name = input.name || input.id
+      if (!name) return
+
+      if (input.type === "checkbox") {
+        formData[name] = input.checked
+      } else if (input.type === "radio") {
+        if (input.checked) {
+          formData[name] = input.value
+        }
+      } else {
+        formData[name] = input.value
+      }
+    })
+
+    return formData
+  }
+
+  const validateForm = (): { isValid: boolean, errors: { [string]: string } } => {
+    const validationErrors = {}
+    if (!formRef.current) return { isValid: true, errors: {} }
+
+    const requiredInputs = formRef.current.querySelectorAll("[required]")
+    requiredInputs.forEach(input => {
+      const name = input.name || input.id
+      if (!name) return
+
+      if (input.type === "checkbox" && !input.checked) {
+        validationErrors[name] = "This field is required"
+      } else if (!input.value || !input.value.trim()) {
+        validationErrors[name] = "This field is required"
+      }
+
+      // Email validation
+      if (input.type === "email" && input.value) {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+        if (!emailRegex.test(input.value)) {
+          validationErrors[name] = "Please enter a valid email address"
+        }
+      }
+    })
+
+    return {
+      isValid: Object.keys(validationErrors).length === 0,
+      errors: validationErrors,
+    }
+  }
+
+  const scrollToFirstError = () => {
+    if (!formRef.current) return
+    const firstErrorField = formRef.current.querySelector(".dcf-field-error")
+    if (firstErrorField) {
+      firstErrorField.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+  }
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault()
+
+    // Validate
+    const { isValid, errors: validationErrors } = validateForm()
+    setErrors(validationErrors)
+
+    if (!isValid) {
+      setFormState("error")
+      setTimeout(scrollToFirstError, 100)
+      return
+    }
+
+    // Collect form data and submit
+    setFormState("submitting")
+    const formData = collectFormData()
+
+    try {
+      const order = {
+        order_type: "data_capture",
+        data: formData,
+        external_id: uuid(),
+        source: "online",
+      }
+
+      await sendOrder(order)
+      setFormState("success")
+
+      // Redirect if URL is configured
+      if (redirectUrl) {
+        window.location.href = redirectUrl
+      }
+    } catch (err) {
+      console.error("Data capture form submission failed:", err)
+      setFormState("error")
+    }
+  }
+
+  const renderMessage = () => {
+    if (formState === "success") {
+      return (
+        <div
+          className="dcf-message dcf-message-success"
+          style={{
+            color: successFontColor || undefined,
+            backgroundColor: successBgColor || undefined,
+          }}
+          dangerouslySetInnerHTML={{ __html: successFormMessage }}
+        />
+      )
+    }
+
+    if (formState === "error") {
+      return (
+        <div
+          className="dcf-message dcf-message-error"
+          style={{
+            color: invalidFontColor || undefined,
+            backgroundColor: invalidBgColor || undefined,
+          }}
+          dangerouslySetInnerHTML={{ __html: invalidFormMessage }}
+        />
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <div className="dcf-container">
+      <form ref={formRef} onSubmit={handleSubmit} noValidate className={`dcf-form ${isDisabled ? "dcf-disabled" : ""}`}>
+        {requiredLabel && (
+          <p className="dcf-required-label">
+            <span className="dcf-asterisk">*</span> {requiredLabel}
+          </p>
+        )}
+
+        <div className="dcf-fields">
+          {children}
+        </div>
+
+        {Object.keys(errors).length > 0 && (
+          <div className="dcf-field-errors">
+            {Object.entries(errors).map(([field, message]) => (
+              <p key={field} className="dcf-field-error">
+                {field}: {String(message)}
+              </p>
+            ))}
+          </div>
+        )}
+
+        {renderMessage()}
+
+        <div className="dcf-submit-container">
+          <button
+            type="submit"
+            className="dcf-submit-button"
+            disabled={isDisabled}
+          >
+            {formState === "submitting" ? (
+              <span className="dcf-spinner" />
+            ) : (
+              submitLabel
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default MaltegoDataCaptureForm

--- a/components/maltego-data-capture-form/package.json
+++ b/components/maltego-data-capture-form/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@limio/maltego-data-capture-form",
+  "version": "1.0.0",
+  "description": "Maltego Data Capture Form - collects customer information and sends to Salesforce via platform event, with optional redirect on success",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "uuid": "^9.0.0"
+  },
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "requiredLabel",
+      "label": "Required field label",
+      "type": "string",
+      "default": "Required"
+    },
+    {
+      "id": "optionalLabel",
+      "label": "Optional field label",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "id": "submitLabel",
+      "label": "Submit button label",
+      "type": "string",
+      "default": "Submit"
+    },
+    {
+      "id": "successFormMessage__limio_richtext",
+      "label": "Success form message",
+      "type": "richtext",
+      "default": "Thank you for submitting your information."
+    },
+    {
+      "id": "successFormMessageFontColor__limio_color",
+      "label": "Success form message font color",
+      "type": "color",
+      "default": ""
+    },
+    {
+      "id": "successFormMessageBackgroundColor__limio_color",
+      "label": "Success form message background color",
+      "type": "color",
+      "default": ""
+    },
+    {
+      "id": "invalidFormMessage__limio_richtext",
+      "label": "Invalid form message",
+      "type": "richtext",
+      "default": "Your information could not be submitted. Please check your answers and try again."
+    },
+    {
+      "id": "invalidFormMessageFontColor__limio_color",
+      "label": "Invalid form message font color",
+      "type": "color",
+      "default": ""
+    },
+    {
+      "id": "invalidFormMessageBackgroundColor__limio_color",
+      "label": "Invalid form message background color",
+      "type": "color",
+      "default": ""
+    },
+    {
+      "id": "redirectUrl",
+      "label": "Redirect URL",
+      "type": "string",
+      "default": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New `maltego-data-capture-form` component — custom variant of the standard Data Capture Form for Maltego's vetting flow
- Replicates all OOTB Data Capture Form behavior (field validation, `sendOrder` with `data_capture` order type, success/error messaging, disabled state after submission)
- Adds **Redirect URL** prop (string, default empty) — if populated, navigates to that relative path on successful submission (e.g. `/checkout`)
- Storybook config updated to include component stories; `sendOrder` mock added for dev

## Test plan
- [ ] Deploy to saas-dev and add MALTEGO-DATA-CAPTURE-FORM to a page
- [ ] Configure subcomponent fields (email, org type, country)
- [ ] Submit form and verify data_capture order is created
- [ ] Set Redirect URL to `/checkout` and verify redirect after successful submission
- [ ] Leave Redirect URL empty and verify user stays on page with success message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Maltego Data Capture Form component with built-in validation for required fields and email formats.
  * Added customizable form labels, success/error messages, color schemes, and optional redirect functionality after submission.

* **Documentation**
  * Added Storybook story variants showcasing default, redirect URL, and custom message configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->