### PR TITLE
Fix saved-payment-checkout crash outside PaymentManager

### DIFF
--- a/components/saved-payment-checkout/index.tsx
+++ b/components/saved-payment-checkout/index.tsx
@@ -9,9 +9,19 @@ import "./index.css"
 
 const PAYMENT_TYPE = "saved_payment"
 
+// Safe wrapper — usePaymentManagerContext throws if rendered outside a PaymentManager provider.
+// This can happen in page builder preview or when the component is placed outside the form.
+function useSafePaymentManagerContext() {
+    try {
+        return usePaymentManagerContext()
+    } catch {
+        return { form: null, store: null }
+    }
+}
+
 function SavedPaymentCheckout() {
     const props = useStaticProps()
-    const { form, store } = usePaymentManagerContext()
+    const { form, store } = useSafePaymentManagerContext()
 
     const { customer } = useLimioUserCustomer()
     const { paymentMethods } = useLimioUserPaymentMethods(customer?.id, {


### PR DESCRIPTION
## Summary
- Fixes `usePaymentManagerContext must be used under a PaymentManager` error when the saved-payment-checkout component is rendered outside a PaymentManager provider (e.g. in page builder preview)
- Adds a `useSafePaymentManagerContext()` wrapper that catches the throw and returns `{ form: null, store: null }`, so the component renders the payment cards UI gracefully without checkout integration
- All existing effects already guard on `if (!form || !store) return`, so null values are handled safely

## Test plan
- [ ] Verify component no longer crashes in page builder preview
- [ ] Verify component still works correctly inside a PaymentManager (checkout flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)