### PR TITLE
Fix padStart crash on expiry month

### DIFF
--- a/components/saved-payment-checkout/components/CheckoutPaymentCard.tsx
+++ b/components/saved-payment-checkout/components/CheckoutPaymentCard.tsx
@@ -83,8 +83,8 @@ function getExpiryStatus(month: string, year: string): ExpiryStatus {
     return "valid"
 }
 
-function formatExpiryLabel(template: string, month: string, year: string): string {
-    const expiryDate = `${month.padStart(2, "0")}/${year}`
+function formatExpiryLabel(template: string, month: string | number, year: string | number): string {
+    const expiryDate = `${String(month).padStart(2, "0")}/${year}`
     return template.replace("{{expiryDate}}", expiryDate)
 }
 


### PR DESCRIPTION
## Summary
- Fixes `TypeError: month.padStart is not a function` in `CheckoutPaymentCard`
- The real Zuora API returns `expirationMonth` as a number (e.g. `3`), not a string (`"03"`)
- Coerces to `String()` before calling `.padStart(2, "0")`

## Test plan
- [x] Verify component renders without crash on live checkout page

🤖 Generated with [Claude Code](https://claude.com/claude-code)