### PR TITLE
Fix saved-payment-checkout styling and padStart crash

### DIFF
--- a/component-playground/packages/limio/internal-checkout-sdk/index.js
+++ b/component-playground/packages/limio/internal-checkout-sdk/index.js
@@ -146,23 +146,6 @@ export function useLimioUserPaymentMethods() {
             }
           }
         }
-      },
-      {
-        id: "pm-mock-paypal",
-        type: "zuora",
-        data: {
-          type: "zuora",
-          method: "PayPal",
-          brand: "PayPal",
-          email: "test@example.com",
-          zuora: {
-            refId: "mock-zuora-ref-pp",
-            result: {
-              PaymentGateway: "Test Gateway",
-              Type: "PayPal"
-            }
-          }
-        }
       }
     ],
     revalidate: () => {},

--- a/components/saved-payment-checkout/components/CheckoutPaymentCard.tsx
+++ b/components/saved-payment-checkout/components/CheckoutPaymentCard.tsx
@@ -83,8 +83,8 @@ function getExpiryStatus(month: string, year: string): ExpiryStatus {
     return "valid"
 }
 
-function formatExpiryLabel(template: string, month: string, year: string): string {
-    const expiryDate = `${month.padStart(2, "0")}/${year}`
+function formatExpiryLabel(template: string, month: string | number, year: string | number): string {
+    const expiryDate = `${String(month).padStart(2, "0")}/${year}`
     return template.replace("{{expiryDate}}", expiryDate)
 }
 

--- a/components/saved-payment-checkout/index.css
+++ b/components/saved-payment-checkout/index.css
@@ -15,6 +15,7 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     color: var(--spc-text);
     -webkit-font-smoothing: antialiased;
+    max-width: 100%;
 }
 
 .spc-container *,
@@ -23,41 +24,45 @@
     box-sizing: border-box;
 }
 
-.spc-heading {
+.spc-container .spc-heading {
     font-size: 15px;
     font-weight: 600;
     margin: 0 0 12px;
+    padding: 0;
     color: var(--spc-text);
+    line-height: 1.4;
 }
 
 /* Fieldset & legend — visually clean, semantically correct */
-.spc-fieldset {
+.spc-container .spc-fieldset {
     border: none;
     margin: 0;
     padding: 0;
+    min-width: 0;
 }
 
-.spc-legend {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
+.spc-container .spc-legend {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
 }
 
 /* Card list */
-.spc-card-list {
+.spc-container .spc-card-list {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    width: 100%;
 }
 
-/* Card — now a <label> wrapping a radio input */
-.spc-card {
+/* Card — a <label> wrapping a radio input */
+.spc-container .spc-card {
     display: flex;
     align-items: center;
     gap: 12px;
@@ -65,117 +70,128 @@
     border: 2px solid var(--spc-border);
     border-radius: 10px;
     padding: 16px 20px;
+    margin: 0;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
     cursor: pointer;
     transition: border-color 0.15s, background-color 0.15s, box-shadow 0.15s;
+    width: 100%;
+    text-align: left;
+    line-height: 1.4;
 }
 
-.spc-card:hover {
+.spc-container .spc-card:hover {
     border-color: #c5cad3;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
-.spc-card--selected {
+.spc-container .spc-card--selected {
     border-color: var(--spc-selected);
     background-color: var(--spc-selected-bg);
     box-shadow: 0 0 0 1px var(--spc-selected);
 }
 
-.spc-card--selected:hover {
+.spc-container .spc-card--selected:hover {
     border-color: var(--spc-selected);
     box-shadow: 0 0 0 1px var(--spc-selected);
 }
 
 /* Visually hidden radio input */
-.spc-radio-input {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
+.spc-container .spc-radio-input {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
 }
 
 /* Focus visible ring on the card when radio is focused via keyboard */
-.spc-radio-input:focus-visible + .spc-card-body {
-    outline: none;
-}
-
-.spc-card:has(.spc-radio-input:focus-visible) {
+.spc-container .spc-card:has(.spc-radio-input:focus-visible) {
     outline: 2px solid #2563eb;
     outline-offset: 2px;
 }
 
 /* Card body takes remaining space */
-.spc-card-body {
+.spc-container .spc-card-body {
     flex: 1;
     min-width: 0;
 }
 
-.spc-card-header {
+.spc-container .spc-card-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
 }
 
-.spc-card-info {
+.spc-container .spc-card-info {
     display: flex;
     flex-direction: column;
     gap: 2px;
 }
 
-.spc-card-top-row {
+.spc-container .spc-card-top-row {
     display: flex;
     align-items: center;
     gap: 8px;
 }
 
-.spc-card-label {
+.spc-container .spc-card-label {
     font-size: 14px;
     font-weight: 600;
     color: var(--spc-text);
+    display: inline;
 }
 
-.spc-card-number {
+.spc-container .spc-card-number {
     font-size: 14px;
     font-weight: 500;
     color: var(--spc-text-muted);
     letter-spacing: 0.02em;
+    display: inline;
 }
 
-.spc-icon {
+/* Icon — must constrain SVG size explicitly */
+.spc-container .spc-icon {
     width: 40px;
     height: 28px;
+    min-width: 40px;
+    max-width: 40px;
+    min-height: 28px;
+    max-height: 28px;
     color: var(--spc-text-muted);
     flex-shrink: 0;
+    overflow: hidden;
 }
 
-.spc-icon svg {
-    width: 100%;
-    height: 100%;
+.spc-container .spc-icon svg {
+    width: 40px !important;
+    height: 28px !important;
+    max-width: 40px !important;
+    max-height: 28px !important;
+    display: block;
 }
 
-.spc-expiry {
+.spc-container .spc-expiry {
     font-size: 13px;
     color: var(--spc-text-muted);
     margin-top: 2px;
 }
 
-.spc-expiry--expired {
+.spc-container .spc-expiry--expired {
     color: var(--spc-expired);
     font-weight: 500;
 }
 
-.spc-expiry--expiring-soon {
+.spc-container .spc-expiry--expiring-soon {
     color: var(--spc-expiring);
     font-weight: 500;
 }
 
-.spc-card-footer {
+.spc-container .spc-card-footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -184,26 +200,33 @@
     border-top: 1px solid var(--spc-border);
 }
 
-.spc-holder {
+.spc-container .spc-holder {
     font-size: 13px;
     color: var(--spc-text-muted);
 }
 
 /* Check indicator (right side of card) */
-.spc-check-indicator {
+.spc-container .spc-check-indicator {
     flex-shrink: 0;
     width: 20px;
     height: 20px;
+    min-width: 20px;
     color: var(--spc-border);
     transition: color 0.15s;
 }
 
-.spc-card--selected .spc-check-indicator {
+.spc-container .spc-check-indicator svg {
+    width: 20px !important;
+    height: 20px !important;
+    display: block;
+}
+
+.spc-container .spc-card--selected .spc-check-indicator {
     color: var(--spc-selected);
 }
 
 /* "Use a different card" link at bottom of list */
-.spc-add-method-link {
+.spc-container .spc-add-method-link {
     display: block;
     margin-top: 12px;
     font-size: 13px;
@@ -217,12 +240,12 @@
     transition: color 0.15s, border-color 0.15s;
 }
 
-.spc-add-method-link:hover {
+.spc-container .spc-add-method-link:hover {
     color: var(--spc-text);
     border-color: #c5cad3;
 }
 
-.spc-warning {
+.spc-container .spc-warning {
     background: var(--spc-warning-bg);
     border: 1px solid var(--spc-warning-border);
     border-radius: 10px;
@@ -232,25 +255,25 @@
     line-height: 1.5;
 }
 
-.spc-skeleton {
+.spc-container .spc-skeleton {
     padding: 16px 20px;
     background: var(--spc-card);
     border: 1px solid var(--spc-border);
     border-radius: 10px;
 }
 
-.spc-skeleton-line {
+.spc-container .spc-skeleton-line {
     height: 14px;
     background: #e5e7eb;
     border-radius: 4px;
     animation: spc-pulse 1.5s ease-in-out infinite;
 }
 
-.spc-skeleton-line--short {
+.spc-container .spc-skeleton-line--short {
     width: 40%;
 }
 
-.spc-skeleton-line--medium {
+.spc-container .spc-skeleton-line--medium {
     width: 60%;
     margin-top: 10px;
 }
@@ -261,7 +284,7 @@
 }
 
 @media (max-width: 600px) {
-    .spc-card {
+    .spc-container .spc-card {
         padding: 14px 16px;
     }
 }


### PR DESCRIPTION
## Summary
- **CSS specificity fix**: All selectors now prefixed with `.spc-container` to prevent parent page styles from overriding component layout
- **Icon size fix**: Explicit `!important` size constraints on SVGs (40x28px for card icons, 20x20px for checkmarks) — parent page was rendering them at full size
- **Legend/radio hidden fix**: `!important` on visually-hidden styles for legend and radio inputs — parent fieldset/input styles were making them visible
- **padStart fix**: Coerce `month`/`year` to `String()` before `.padStart()` — real Zuora API returns numbers
- **Mock reduced**: Storybook mock trimmed from 3 to 2 payment methods

## Test plan
- [ ] Deploy and verify card icons render at correct small size
- [ ] Verify "Select payment method" legend is hidden
- [ ] Verify cards stack vertically in a clean list
- [ ] Verify no padStart crash with real payment data

🤖 Generated with [Claude Code](https://claude.com/claude-code)