### PR TITLE
Fix: saved payment bypasses payment type required validation

### DIFF
--- a/components/saved-payment-checkout/index.tsx
+++ b/components/saved-payment-checkout/index.tsx
@@ -134,22 +134,6 @@ function SavedPaymentCheckout({
     return (
         <div style={s.container}>
             {heading && <h4 style={s.heading}>{heading}</h4>}
-            {/* Hidden radio satisfies the core payment-method-selector-field's
-                required validation on name="paymentType". When a saved card is
-                selected this is checked, so the form can submit without forcing
-                the user to also pick Card/DD/Invoice. */}
-            {selectedPaymentMethodId && (
-                <input
-                    type="radio"
-                    name="paymentType"
-                    value={PAYMENT_TYPE}
-                    checked
-                    readOnly
-                    style={s.radioInput}
-                    aria-hidden="true"
-                    tabIndex={-1}
-                />
-            )}
             <fieldset style={s.fieldset}>
                 <legend style={s.legend}>Select payment method</legend>
                 <div style={s.cardList}>

--- a/components/saved-payment-checkout/index.tsx
+++ b/components/saved-payment-checkout/index.tsx
@@ -134,6 +134,18 @@ function SavedPaymentCheckout({
     return (
         <div style={s.container}>
             {heading && <h4 style={s.heading}>{heading}</h4>}
+            {selectedPaymentMethodId && (
+                <input
+                    type="radio"
+                    name="paymentType"
+                    value={PAYMENT_TYPE}
+                    checked
+                    readOnly
+                    style={s.radioInput}
+                    aria-hidden="true"
+                    tabIndex={-1}
+                />
+            )}
             <fieldset style={s.fieldset}>
                 <legend style={s.legend}>Select payment method</legend>
                 <div style={s.cardList}>

--- a/components/saved-payment-checkout/index.tsx
+++ b/components/saved-payment-checkout/index.tsx
@@ -134,6 +134,22 @@ function SavedPaymentCheckout({
     return (
         <div style={s.container}>
             {heading && <h4 style={s.heading}>{heading}</h4>}
+            {/* Hidden radio satisfies the core payment-method-selector-field's
+                required validation on name="paymentType". When a saved card is
+                selected this is checked, so the form can submit without forcing
+                the user to also pick Card/DD/Invoice. */}
+            {selectedPaymentMethodId && (
+                <input
+                    type="radio"
+                    name="paymentType"
+                    value={PAYMENT_TYPE}
+                    checked
+                    readOnly
+                    style={s.radioInput}
+                    aria-hidden="true"
+                    tabIndex={-1}
+                />
+            )}
             <fieldset style={s.fieldset}>
                 <legend style={s.legend}>Select payment method</legend>
                 <div style={s.cardList}>


### PR DESCRIPTION
## Summary
The core `payment-method-selector-field` uses `<input type="radio" name="paymentType" required>`. When a user selects a saved payment method instead of Card/DD/Invoice, none of the core radios are checked, so the browser blocks form submission with "Please select one of these options."

**Fix**: When a saved card is selected, render a hidden checked `<input type="radio" name="paymentType" value="saved_payment">` that satisfies the browser's required validation on the radio group.

## Test plan
- [ ] Select a saved payment method and click Submit — form should submit without "Please select one of these options" error
- [ ] Select Card/DD/Invoice instead — core selector works as before, hidden radio unchecks

🤖 Generated with [Claude Code](https://claude.com/claude-code)