### PR TITLE
Fix JSON-LD schema validation issues

### DIFF
--- a/components/json-ld-schema/__tests__/buildJsonLd.test.js
+++ b/components/json-ld-schema/__tests__/buildJsonLd.test.js
@@ -166,10 +166,67 @@ describe("buildOfferSchema", () => {
     expect(result.isRelatedTo[1]).toEqual({ "@type": "Offer", name: "Premium Plan" })
   })
 
+  test("7b. Upsell mapping — filters out entries with empty names", () => {
+    const offer = makeOffer({
+      attributes: {
+        display_name__limio: "Pro Plan",
+        upsell_offers__limio: {
+          items: [
+            { label: "" },
+            { label: "Enterprise Plan" },
+            { name: "" },
+          ],
+        },
+      },
+    })
+    const result = buildOfferSchema(offer, "Subscription")
+    expect(result.isRelatedTo).toHaveLength(1)
+    expect(result.isRelatedTo[0].name).toBe("Enterprise Plan")
+  })
+
+  test("7c. Upsell mapping — omits isRelatedTo when all names empty", () => {
+    const offer = makeOffer({
+      attributes: {
+        display_name__limio: "Pro Plan",
+        upsell_offers__limio: {
+          items: [{ label: "" }, { name: "" }],
+        },
+      },
+    })
+    const result = buildOfferSchema(offer, "Subscription")
+    expect(result.isRelatedTo).toBeUndefined()
+  })
+
   test("8. No upsells — omits isRelatedTo when no upsell data", () => {
     const offer = makeOffer()
     const result = buildOfferSchema(offer, "Subscription")
     expect(result.isRelatedTo).toBeUndefined()
+  })
+
+  test("price fallback — uses price__limio when data.price is empty", () => {
+    const offer = makeOffer({
+      price: [],
+      attributes: {
+        display_name__limio: "Fallback Plan",
+        price__limio: [{ value: 49.99, currencyCode: "EUR", repeat_interval: 1, repeat_interval_type: "months" }],
+      },
+    })
+    const result = buildOfferSchema(offer, "Subscription")
+    expect(result.price).toBe("49.99")
+    expect(result.priceCurrency).toBe("EUR")
+    expect(result.priceSpecification.unitCode).toBe("MON")
+  })
+
+  test("empty description — omits description field when empty", () => {
+    const offer = makeOffer({
+      attributes: {
+        display_name__limio: "No Desc Plan",
+        offer_features__limio: undefined,
+        checkout_description__limio: undefined,
+      },
+    })
+    const result = buildOfferSchema(offer, "Subscription")
+    expect(result.description).toBeUndefined()
   })
 
   test("12. Image attachment — maps attachments[0].url to image", () => {

--- a/components/json-ld-schema/buildJsonLd.js
+++ b/components/json-ld-schema/buildJsonLd.js
@@ -56,14 +56,21 @@ export function extractFeatureList(html) {
  */
 export function buildOfferSchema(offer, category) {
   const attrs = offer?.data?.attributes || {}
-  const priceData = offer?.data?.price?.[0]
+  // Price lives at offer.data.price[0] in mock SDK but at
+  // offer.data.attributes.price__limio[0] in real Limio tenants — try both
+  const priceData = offer?.data?.price?.[0] || attrs.price__limio?.[0]
   const imageUrl = offer?.data?.attachments?.[0]?.url
 
   const schema = {
     "@type": "Offer",
     name: attrs.display_name__limio || offer?.name || "",
-    description: stripHtml(attrs.checkout_description__limio || attrs.offer_features__limio),
     category: category || "Subscription",
+  }
+
+  // Only include description if non-empty
+  const desc = stripHtml(attrs.checkout_description__limio || attrs.offer_features__limio)
+  if (desc) {
+    schema.description = desc
   }
 
   // Price fields — omit entirely for "contact sales" offers with no price
@@ -87,18 +94,27 @@ export function buildOfferSchema(offer, category) {
     }
   }
 
-  // Upsell offers → isRelatedTo
+  // Upsell offers → isRelatedTo (filter out entries with empty names)
   const upsellItems = attrs.upsell_offers__limio?.items
   if (upsellItems && upsellItems.length > 0) {
-    schema.isRelatedTo = upsellItems.map((item) => ({
-      "@type": "Offer",
-      name: item.label || item.name || "",
-    }))
+    const validUpsells = upsellItems
+      .filter((item) => item.label || item.name)
+      .map((item) => ({
+        "@type": "Offer",
+        name: item.label || item.name,
+      }))
+    if (validUpsells.length > 0) {
+      schema.isRelatedTo = validUpsells
+    }
   }
 
-  // Image attachment
+  // Image attachment — ensure absolute URL
   if (imageUrl) {
-    schema.image = imageUrl
+    if (imageUrl.startsWith("http")) {
+      schema.image = imageUrl
+    } else if (typeof window !== "undefined" && window.location?.origin) {
+      schema.image = window.location.origin + imageUrl
+    }
   }
 
   // Features as itemOffered Service with OfferCatalog


### PR DESCRIPTION
## Summary
- Fall back to `offer.data.attributes.price__limio[0]` when `offer.data.price[0]` is empty (real Limio tenants store price at a different path than the mock SDK)
- Filter out `isRelatedTo` entries with empty names instead of emitting `{"name": ""}`
- Omit `description` field entirely when empty instead of outputting `""`
- Convert relative image URLs to absolute using `window.location.origin`

## Test plan
- [x] 33 unit tests pass (4 new tests for the fixes)
- [ ] Redeploy and verify prices appear in JSON-LD on https://saas-dev-shop.prod.limio.com/leemeeo-pricing
- [ ] Re-validate at https://validator.schema.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)