### PR TITLE
Add purchase links with UTM attribution to JSON-LD schema

### DIFF
--- a/components/json-ld-schema/__tests__/buildJsonLd.test.js
+++ b/components/json-ld-schema/__tests__/buildJsonLd.test.js
@@ -1,6 +1,7 @@
 import {
   buildJsonLd,
   buildOfferSchema,
+  buildPurchaseUrl,
   stripHtml,
   extractFeatureList,
   mapBillingInterval,
@@ -11,6 +12,7 @@ import {
 function makeOffer(overrides = {}) {
   return {
     id: "offer-test",
+    path: overrides.path || "/offers2/test-offer",
     name: "Test Offer",
     data: {
       attributes: {
@@ -115,6 +117,101 @@ describe("extractFeatureList", () => {
     const result = extractFeatureList(html)
     expect(result).toHaveLength(1)
     expect(result[0].itemOffered.name).toBe("Valid")
+  })
+})
+
+describe("buildPurchaseUrl", () => {
+  test("builds full purchase URL with UTM params", () => {
+    const offer = makeOffer()
+    const config = {
+      shopDomain: "https://shop.example.com",
+      checkoutBasePath: "/checkout",
+      utmSource: "ai",
+      utmMedium: "llm",
+      utmCampaign: "limio-pricing-page",
+    }
+    const result = buildPurchaseUrl(offer, config)
+    expect(result).toBe(
+      "https://shop.example.com/checkout?purchase=/offers2/test-offer&utm_source=ai&utm_medium=llm&utm_campaign=limio-pricing-page"
+    )
+  })
+
+  test("returns null when shopDomain is empty", () => {
+    const offer = makeOffer()
+    expect(buildPurchaseUrl(offer, { shopDomain: "" })).toBeNull()
+    expect(buildPurchaseUrl(offer, {})).toBeNull()
+    expect(buildPurchaseUrl(offer, null)).toBeNull()
+  })
+
+  test("returns null when offer has no path or id", () => {
+    const offer = { name: "No Path" }
+    const config = { shopDomain: "https://shop.example.com" }
+    expect(buildPurchaseUrl(offer, config)).toBeNull()
+  })
+
+  test("falls back to offer.id when path is missing", () => {
+    const offer = { id: "/offers2/fallback-offer", name: "Fallback" }
+    const config = { shopDomain: "https://shop.example.com", checkoutBasePath: "/checkout" }
+    const result = buildPurchaseUrl(offer, config)
+    expect(result).toBe("https://shop.example.com/checkout?purchase=/offers2/fallback-offer")
+  })
+
+  test("omits UTM params when all empty", () => {
+    const offer = makeOffer()
+    const config = {
+      shopDomain: "https://shop.example.com",
+      checkoutBasePath: "/checkout",
+      utmSource: "",
+      utmMedium: "",
+      utmCampaign: "",
+    }
+    const result = buildPurchaseUrl(offer, config)
+    expect(result).toBe("https://shop.example.com/checkout?purchase=/offers2/test-offer")
+    expect(result).not.toContain("utm_")
+  })
+
+  test("includes only provided UTM params", () => {
+    const offer = makeOffer()
+    const config = {
+      shopDomain: "https://shop.example.com",
+      checkoutBasePath: "/checkout",
+      utmSource: "google",
+      utmMedium: "",
+      utmCampaign: "",
+    }
+    const result = buildPurchaseUrl(offer, config)
+    expect(result).toContain("utm_source=google")
+    expect(result).not.toContain("utm_medium")
+    expect(result).not.toContain("utm_campaign")
+  })
+
+  test("strips trailing slash from shopDomain", () => {
+    const offer = makeOffer()
+    const config = { shopDomain: "https://shop.example.com/", checkoutBasePath: "/checkout" }
+    const result = buildPurchaseUrl(offer, config)
+    expect(result).toContain("https://shop.example.com/checkout")
+    expect(result).not.toContain("//checkout")
+  })
+
+  test("handles custom checkout path", () => {
+    const offer = makeOffer()
+    const config = { shopDomain: "https://shop.example.com", checkoutBasePath: "/custom-cart" }
+    const result = buildPurchaseUrl(offer, config)
+    expect(result).toContain("/custom-cart?purchase=")
+  })
+
+  test("encodes special characters in UTM values", () => {
+    const offer = makeOffer()
+    const config = {
+      shopDomain: "https://shop.example.com",
+      checkoutBasePath: "/checkout",
+      utmSource: "ai bot",
+      utmMedium: "",
+      utmCampaign: "test&value",
+    }
+    const result = buildPurchaseUrl(offer, config)
+    expect(result).toContain("utm_source=ai%20bot")
+    expect(result).toContain("utm_campaign=test%26value")
   })
 })
 
@@ -249,6 +346,29 @@ describe("buildOfferSchema", () => {
     const result = buildOfferSchema(offer, "Subscription")
     expect(result.name).toBe("Fallback Name")
   })
+
+  test("includes checkoutPageURLTemplate when purchaseConfig has shopDomain", () => {
+    const offer = makeOffer()
+    const purchaseConfig = {
+      shopDomain: "https://shop.example.com",
+      checkoutBasePath: "/checkout",
+      utmSource: "ai",
+      utmMedium: "llm",
+      utmCampaign: "pricing",
+    }
+    const result = buildOfferSchema(offer, "Subscription", purchaseConfig)
+    expect(result.checkoutPageURLTemplate).toBe(
+      "https://shop.example.com/checkout?purchase=/offers2/test-offer&utm_source=ai&utm_medium=llm&utm_campaign=pricing"
+    )
+    expect(result.url).toBe(result.checkoutPageURLTemplate)
+  })
+
+  test("omits checkoutPageURLTemplate when no shopDomain", () => {
+    const offer = makeOffer()
+    const result = buildOfferSchema(offer, "Subscription", {})
+    expect(result.checkoutPageURLTemplate).toBeUndefined()
+    expect(result.url).toBeUndefined()
+  })
 })
 
 describe("buildJsonLd", () => {
@@ -328,5 +448,46 @@ describe("buildJsonLd", () => {
   test("handles null/undefined offers gracefully", () => {
     const result = buildJsonLd(null, null, defaultConfig)
     expect(result.mainEntity.offers).toHaveLength(0)
+  })
+
+  test("includes checkoutPageURLTemplate on offers when shopDomain is set", () => {
+    const offers = [makeOffer()]
+    const config = {
+      ...defaultConfig,
+      shopDomain: "https://saas-dev-shop.prod.limio.com",
+      checkoutBasePath: "/checkout",
+      utmSource: "ai",
+      utmMedium: "llm",
+      utmCampaign: "limio-pricing-page",
+    }
+    const result = buildJsonLd(offers, [], config)
+    const offer = result.mainEntity.offers[0]
+    expect(offer.checkoutPageURLTemplate).toBe(
+      "https://saas-dev-shop.prod.limio.com/checkout?purchase=/offers2/test-offer&utm_source=ai&utm_medium=llm&utm_campaign=limio-pricing-page"
+    )
+    expect(offer.url).toBe(offer.checkoutPageURLTemplate)
+  })
+
+  test("omits checkoutPageURLTemplate when shopDomain not configured", () => {
+    const offers = [makeOffer()]
+    const result = buildJsonLd(offers, [], defaultConfig)
+    expect(result.mainEntity.offers[0].checkoutPageURLTemplate).toBeUndefined()
+  })
+
+  test("purchase links work for add-ons too", () => {
+    const offers = [makeOffer()]
+    const addOns = [makeOffer({ path: "/offers2/mobile-addon", attributes: { display_name__limio: "Mobile Add-On" } })]
+    const config = {
+      ...defaultConfig,
+      includeAddOns: true,
+      shopDomain: "https://shop.example.com",
+      utmSource: "ai",
+      utmMedium: "llm",
+      utmCampaign: "pricing",
+    }
+    const result = buildJsonLd(offers, addOns, config)
+    const addOnOffer = result.mainEntity.offers[1]
+    expect(addOnOffer.checkoutPageURLTemplate).toContain("/offers2/mobile-addon")
+    expect(addOnOffer.checkoutPageURLTemplate).toContain("utm_source=ai")
   })
 })

--- a/components/json-ld-schema/buildJsonLd.js
+++ b/components/json-ld-schema/buildJsonLd.js
@@ -50,11 +50,46 @@ export function extractFeatureList(html) {
 }
 
 /**
+ * Build the checkout purchase URL for an offer with optional UTM tracking.
+ * Uses Limio purchase link format: /checkout?purchase=/offers2/offerName
+ * @param {object} offer - Limio offer object
+ * @param {object} purchaseConfig - Purchase link configuration
+ * @returns {string|null} Full checkout URL or null if not enough data
+ */
+export function buildPurchaseUrl(offer, purchaseConfig) {
+  const { shopDomain = "", checkoutBasePath = "/checkout", utmSource = "", utmMedium = "", utmCampaign = "" } = purchaseConfig || {}
+
+  if (!shopDomain) return null
+
+  // Derive offer path from offer.path (Limio standard) or offer.id
+  const offerPath = offer?.path || offer?.id
+  if (!offerPath) return null
+
+  const baseUrl = shopDomain.replace(/\/+$/, "")
+  const checkoutPath = checkoutBasePath.startsWith("/") ? checkoutBasePath : "/" + checkoutBasePath
+
+  let url = `${baseUrl}${checkoutPath}?purchase=${offerPath}`
+
+  // Append UTM parameters if any are set
+  const utmParams = []
+  if (utmSource) utmParams.push(`utm_source=${encodeURIComponent(utmSource)}`)
+  if (utmMedium) utmParams.push(`utm_medium=${encodeURIComponent(utmMedium)}`)
+  if (utmCampaign) utmParams.push(`utm_campaign=${encodeURIComponent(utmCampaign)}`)
+
+  if (utmParams.length > 0) {
+    url += "&" + utmParams.join("&")
+  }
+
+  return url
+}
+
+/**
  * Map a single Limio offer to a schema.org Offer object.
  * @param {object} offer - Limio offer object
  * @param {string} category - "Subscription" or "Add-On"
+ * @param {object} purchaseConfig - Purchase link configuration for checkoutPageURLTemplate
  */
-export function buildOfferSchema(offer, category) {
+export function buildOfferSchema(offer, category, purchaseConfig) {
   const attrs = offer?.data?.attributes || {}
   // Price lives at offer.data.price[0] in mock SDK but at
   // offer.data.attributes.price__limio[0] in real Limio tenants — try both
@@ -92,6 +127,13 @@ export function buildOfferSchema(offer, category) {
         },
       }
     }
+  }
+
+  // Purchase / checkout link with UTM tracking
+  const purchaseUrl = buildPurchaseUrl(offer, purchaseConfig)
+  if (purchaseUrl) {
+    schema.url = purchaseUrl
+    schema.checkoutPageURLTemplate = purchaseUrl
   }
 
   // Upsell offers → isRelatedTo (filter out entries with empty names)
@@ -153,13 +195,20 @@ export function buildJsonLd(offers, addOns, config) {
     applicationCategory = "BusinessApplication",
     pageDescription = "",
     includeAddOns = false,
+    shopDomain = "",
+    checkoutBasePath = "/checkout",
+    utmSource = "ai",
+    utmMedium = "llm",
+    utmCampaign = "limio-pricing-page",
   } = config || {}
 
-  const mappedOffers = (offers || []).map((offer) => buildOfferSchema(offer, "Subscription"))
+  const purchaseConfig = { shopDomain, checkoutBasePath, utmSource, utmMedium, utmCampaign }
+
+  const mappedOffers = (offers || []).map((offer) => buildOfferSchema(offer, "Subscription", purchaseConfig))
 
   const mappedAddOns =
     includeAddOns && addOns?.length
-      ? addOns.map((addOn) => buildOfferSchema(addOn, "Add-On"))
+      ? addOns.map((addOn) => buildOfferSchema(addOn, "Add-On", purchaseConfig))
       : []
 
   const allOffers = [...mappedOffers, ...mappedAddOns]

--- a/components/json-ld-schema/index.js
+++ b/components/json-ld-schema/index.js
@@ -9,6 +9,11 @@ function JsonLdSchema({
   applicationCategory = "BusinessApplication",
   pageDescription = "",
   includeAddOns = false,
+  shopDomain = "",
+  checkoutBasePath = "/checkout",
+  utmSource = "ai",
+  utmMedium = "llm",
+  utmCampaign = "limio-pricing-page",
 }) {
   const { offers = [], addOns = [] } = useCampaign() || {}
 
@@ -21,6 +26,11 @@ function JsonLdSchema({
     applicationCategory,
     pageDescription,
     includeAddOns,
+    shopDomain,
+    checkoutBasePath,
+    utmSource,
+    utmMedium,
+    utmCampaign,
   })
 
   return (

--- a/components/json-ld-schema/json-ld-schema.stories.js
+++ b/components/json-ld-schema/json-ld-schema.stories.js
@@ -47,6 +47,11 @@ export default {
     applicationCategory: { control: "text" },
     pageDescription: { control: "text" },
     includeAddOns: { control: "boolean" },
+    shopDomain: { control: "text" },
+    checkoutBasePath: { control: "text" },
+    utmSource: { control: "text" },
+    utmMedium: { control: "text" },
+    utmCampaign: { control: "text" },
   },
 }
 
@@ -91,5 +96,37 @@ export const ServiceType = {
     applicationCategory: "",
     pageDescription: "Professional email marketing consulting services",
     includeAddOns: false,
+  },
+}
+
+export const WithPurchaseLinks = {
+  args: {
+    schemaType: "SoftwareApplication",
+    applicationName: "Emma by Marigold",
+    applicationUrl: "https://myemma.com",
+    applicationCategory: "BusinessApplication",
+    pageDescription: "Email marketing pricing plans with purchase links",
+    includeAddOns: true,
+    shopDomain: "https://saas-dev-shop.prod.limio.com",
+    checkoutBasePath: "/checkout",
+    utmSource: "ai",
+    utmMedium: "llm",
+    utmCampaign: "limio-pricing-page",
+  },
+}
+
+export const CustomUtmParams = {
+  args: {
+    schemaType: "SoftwareApplication",
+    applicationName: "Emma by Marigold",
+    applicationUrl: "https://myemma.com",
+    applicationCategory: "BusinessApplication",
+    pageDescription: "Custom UTM attribution example",
+    includeAddOns: false,
+    shopDomain: "https://myemma-shop.prod.limio.com",
+    checkoutBasePath: "/checkout",
+    utmSource: "google",
+    utmMedium: "organic",
+    utmCampaign: "emma-pricing-2026",
   },
 }

--- a/components/json-ld-schema/package.json
+++ b/components/json-ld-schema/package.json
@@ -55,6 +55,36 @@
       "label": "Include cross-sell add-ons in schema?",
       "type": "boolean",
       "default": false
+    },
+    {
+      "id": "shopDomain",
+      "label": "Shop domain for purchase links (e.g. https://shop.example.com)",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "id": "checkoutBasePath",
+      "label": "Checkout page path (e.g. /checkout)",
+      "type": "string",
+      "default": "/checkout"
+    },
+    {
+      "id": "utmSource",
+      "label": "UTM source for purchase link attribution",
+      "type": "string",
+      "default": "ai"
+    },
+    {
+      "id": "utmMedium",
+      "label": "UTM medium for purchase link attribution",
+      "type": "string",
+      "default": "llm"
+    },
+    {
+      "id": "utmCampaign",
+      "label": "UTM campaign for purchase link attribution",
+      "type": "string",
+      "default": "limio-pricing-page"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `checkoutPageURLTemplate` (schema.org v15.0) and `url` fields to each Offer in the JSON-LD structured data
- Purchase links use Limio format: `https://domain.com/checkout?purchase=/offers2/offerName`
- UTM parameters appended for LLM attribution tracking (configurable via props)
- Offer path derived from `offer.path` (Limio standard) with fallback to `offer.id`

## New configurable props
| Prop | Default | Description |
|------|---------|-------------|
| `shopDomain` | `""` | Shop domain (e.g. `https://saas-dev-shop.prod.limio.com`) — required to enable purchase links |
| `checkoutBasePath` | `/checkout` | Checkout page path |
| `utmSource` | `ai` | UTM source parameter |
| `utmMedium` | `llm` | UTM medium parameter |
| `utmCampaign` | `limio-pricing-page` | UTM campaign parameter |

## Example output
```json
{
  "@type": "Offer",
  "name": "Pro Plan Monthly",
  "price": "114.50",
  "priceCurrency": "USD",
  "url": "https://shop.example.com/checkout?purchase=/offers2/pro-monthly&utm_source=ai&utm_medium=llm&utm_campaign=limio-pricing-page",
  "checkoutPageURLTemplate": "https://shop.example.com/checkout?purchase=/offers2/pro-monthly&utm_source=ai&utm_medium=llm&utm_campaign=limio-pricing-page"
}
```

## Why both `url` and `checkoutPageURLTemplate`?
- `url` (inherited from Thing) — broadly supported, used by Google and LLMs to link to the offer
- `checkoutPageURLTemplate` (schema.org v15.0, pending) — specifically designed for checkout links, supports RFC 6570 URL templates

## Test plan
- [x] 47 unit tests pass (9 new tests for `buildPurchaseUrl`, `buildOfferSchema` checkout fields, and `buildJsonLd` integration)
- [x] Tests cover: full URL generation, empty domain handling, missing path fallback, UTM param inclusion/exclusion, URL encoding, custom checkout paths, add-on purchase links
- [ ] Deploy to Limio tenant and verify purchase links load checkout with correct offer
- [ ] Verify UTM params appear in analytics when purchasing via schema link
- [ ] Validate with https://validator.schema.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)