### PR TITLE
Add cart-items-slider component

### DIFF
--- a/component-playground/packages/limio/sdk/src/context.js
+++ b/component-playground/packages/limio/sdk/src/context.js
@@ -24,8 +24,15 @@ export function useBasket() {
     if (context === undefined) {
         throw new Error("useBasket must be used within a LimioProvider");
     }
-    const {basketItems, addToBasket, swapOffer} = dummyContext.shop;
-    return {basketItems, addToBasket, swapOffer};
+    const shop = (context && context.shop) || dummyContext.shop;
+    return {
+        basketItems: shop.basketItems,
+        addToBasket: shop.addToBasket || ((offer) => console.log("[Storybook] addToBasket", offer)),
+        swapOffer: shop.swapOffer || ((itemId, offer) => console.log("[Storybook] swapOffer", itemId, offer)),
+        removeFromBasket: shop.removeFromBasket || (({id} = {}) => console.log("[Storybook] removeFromBasket", id)),
+        updateItemQuantity: shop.updateItemQuantity || ((id, q) => console.log("[Storybook] updateItemQuantity", id, q)),
+        basketLoading: Boolean(shop.basketLoading),
+    };
 }
 
 

--- a/component-playground/src/stories/CartItemsSlider.stories.js
+++ b/component-playground/src/stories/CartItemsSlider.stories.js
@@ -1,0 +1,112 @@
+import React from "react"
+import { LimioProvider, ComponentContext } from "@limio/sdk"
+import CartItemsSlider from "../../../components/cart-items-slider"
+
+// Mock offer with a recurringVolume price — matches the shape
+// QuantitySlider consumes (see components/cart-items-slider/helpers.js).
+const volumeOffer = {
+  name: "Core",
+  path: "/offers/SaaS/Core",
+  id: "offer-core-volume",
+  type: "item",
+  data: {
+    record_type: "offer",
+    record_subtype: null,
+    attachments: [],
+    attributes: {
+      display_name__limio: "Core",
+      display_description__limio: "Best for startups and growing businesses.",
+      allow_multibuy__limio: true,
+      price__limio: [
+        {
+          type: "recurringVolume",
+          currencyCode: "USD",
+          tiers: [
+            { starting_unit: 0, ending_unit: 15000, price: 299, price_format: "FlatFee" },
+            { starting_unit: 15001, ending_unit: 30000, price: 499, price_format: "FlatFee" },
+            { starting_unit: 30001, ending_unit: 60000, price: 559, price_format: "FlatFee" },
+            { starting_unit: 60001, ending_unit: 100000, price: 679, price_format: "FlatFee" },
+            { starting_unit: 100001, ending_unit: 150000, price: 799, price_format: "FlatFee" },
+            { starting_unit: 150001, ending_unit: 200000, price: 999, price_format: "FlatFee" }
+          ]
+        }
+      ]
+    },
+    products: [
+      {
+        attributes: {
+          display_name__limio: "SaaS"
+        }
+      }
+    ]
+  }
+}
+
+const buildOrderItem = (quantity = 15000) => ({
+  id: "order-item-1",
+  quantity,
+  offer: volumeOffer,
+  orderLineItem: {
+    currency: "USD",
+    unitPriceTotal: 299,
+    lineItemTotal: 299,
+    lineItemSubtotal: 299
+  },
+  upsell: []
+})
+
+const mockShop = (quantity) => ({
+  campaign: { name: "Slider Demo", path: "/offers/SaaS", attributes: {} },
+  offers: [],
+  addOns: [],
+  basketItems: [buildOrderItem(quantity)],
+  updateItemQuantity: (id, q) => console.log("[Storybook] updateItemQuantity", id, q),
+  removeFromBasket: ({ id }) => console.log("[Storybook] removeFromBasket", id),
+  swapOffer: (id, offer) => console.log("[Storybook] swapOffer", id, offer),
+  basketLoading: false
+})
+
+export default {
+  title: "Cart Items Slider",
+  component: CartItemsSlider,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story, context) => (
+      <LimioProvider value={{ shop: mockShop(context.args.__startingQuantity || 15000) }}>
+        <ComponentContext.Provider value={context.args}>
+          <Story />
+        </ComponentContext.Provider>
+      </LimioProvider>
+    )
+  ]
+}
+
+const baseArgs = {
+  showIcons: true,
+  offerInformation: "{{data.attributes.display_description__limio}}",
+  lineItemInformation: "",
+  addOnInformation: "{{data.attributes.description__limio}}",
+  perUnitLabel: "{quantity} x {formattedPrice} each",
+  tierLabelTemplate: "{quantity} {unit}",
+  tierUnit: "in monthly expenses",
+  emptyText: "Your cart is empty",
+  emptyCta: "See offers",
+  emptyUrl: "/default",
+  displayUpsellOffers: false,
+  showUpsellPrice: true,
+  readOnly: false,
+  showDiscountNote: false,
+  __startingQuantity: 15000
+}
+
+export const Default = { args: { ...baseArgs } }
+
+export const StartingMidTier = {
+  name: "Starting at tier 3",
+  args: { ...baseArgs, __startingQuantity: 60000 }
+}
+
+export const ReadOnly = {
+  name: "Read-only (no slider)",
+  args: { ...baseArgs, readOnly: true }
+}

--- a/components/cart-items-slider/components/AddOnRow.jsx
+++ b/components/cart-items-slider/components/AddOnRow.jsx
@@ -1,0 +1,83 @@
+import * as React from "react"
+import { useBasket } from "@limio/sdk"
+import QuantitySlider from "./QuantitySlider"
+import {
+  formatCurrency,
+  offerHasMultibuy,
+  parseTemplate
+} from "../helpers"
+
+function AddOnRow({ addOnItem, addOnInformation, perUnitLabel, readOnly, tierLabelTemplate, tierUnit }) {
+  const { offer: addOn, quantity = 1, id } = addOnItem
+  const basket = useBasket() || {}
+  const { removeFromBasket, updateItemQuantity, basketLoading } = basket
+
+  const attributes = addOn?.data?.attributes
+  if (!attributes) {
+    return <div className="cis-banner cis-banner--error">Something went wrong when displaying this add-on.</div>
+  }
+
+  const hasMultibuy = offerHasMultibuy(addOn)
+
+  const onQuantityChange = async (q) => {
+    if (updateItemQuantity) await updateItemQuantity(id, Number(q))
+  }
+
+  const onRemove = async () => {
+    if (removeFromBasket) await removeFromBasket({ id })
+  }
+
+  const orderLineItem = addOnItem.orderLineItem || {}
+  const formattedUnitPrice = orderLineItem.unitPriceTotal != null
+    ? formatCurrency(orderLineItem.unitPriceTotal, orderLineItem.currency)
+    : ""
+  const formattedTotal = orderLineItem.lineItemTotal != null
+    ? formatCurrency(orderLineItem.lineItemTotal, orderLineItem.currency)
+    : ""
+
+  return (
+    <div className="cis-addon-row">
+      <div className="cis-addon-row__text" data-testid="item-description">
+        <span className="cis-addon-row__name">{attributes.display_name__limio}</span>
+        {addOnInformation && (
+          <span
+            className="cis-addon-row__description"
+            dangerouslySetInnerHTML={{ __html: parseTemplate(addOnInformation, addOn) }}
+          />
+        )}
+      </div>
+      <div className="cis-addon-row__controls">
+        {!readOnly && (
+          <QuantitySlider
+            offer={addOn}
+            quantity={quantity}
+            onChange={onQuantityChange}
+            disabled={basketLoading}
+            tierLabelTemplate={tierLabelTemplate}
+            tierUnit={tierUnit}
+          />
+        )}
+        <div className="cis-price-block">
+          <span className="cis-price-block__total" data-testid="item-price">{formattedTotal}</span>
+          {hasMultibuy && formattedUnitPrice && (
+            <span className="cis-price-block__unit" data-testid="item-unit-price">
+              {parseTemplate(perUnitLabel, { formattedPrice: formattedUnitPrice, quantity })}
+            </span>
+          )}
+        </div>
+        {!readOnly && (
+          <button
+            type="button"
+            className="cis-icon-button"
+            onClick={onRemove}
+            aria-label={`Remove Add On ${attributes.display_name__limio}`}
+          >
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AddOnRow

--- a/components/cart-items-slider/components/CartItem.jsx
+++ b/components/cart-items-slider/components/CartItem.jsx
@@ -1,0 +1,177 @@
+import * as React from "react"
+import { useBasket } from "@limio/sdk"
+import QuantitySlider from "./QuantitySlider"
+import AddOnRow from "./AddOnRow"
+import Upsell from "./Upsell"
+import {
+  formatCurrency,
+  getDiscountMessage,
+  getDiscountNote,
+  offerHasMultibuy,
+  parseTemplate
+} from "../helpers"
+
+function CartItem({ orderItem, componentProps, addOnItems = [] }) {
+  const {
+    showIcons,
+    offerInformation,
+    lineItemInformation,
+    addOnInformation,
+    perUnitLabel,
+    displayUpsellOffers,
+    showUpsellPrice,
+    readOnly,
+    showDiscountNote,
+    tierLabelTemplate,
+    tierUnit
+  } = componentProps
+
+  const basket = useBasket() || {}
+  const { removeFromBasket, swapOffer, updateItemQuantity, basketLoading } = basket
+
+  const quantity = orderItem.quantity || 1
+  const shouldDisplayUpsellOffers =
+    displayUpsellOffers && !readOnly && (orderItem.upsell?.length || 0) > 0
+
+  const { orderLineItem = {}, offer } = orderItem
+  const offerAttributes = offer?.data?.attributes
+  const product = offer?.data?.products?.[0]
+
+  if (!offerAttributes || !product) {
+    return (
+      <div className="cis-banner cis-banner--error">
+        Something went wrong when displaying this offer. Please try refreshing, and contact us if the issue persists.
+      </div>
+    )
+  }
+
+  const hasMultibuy = offerHasMultibuy(offer)
+  const isLineItem = offer?.data?.record_subtype === "line_item"
+  const itemInformation = isLineItem ? lineItemInformation : offerInformation
+
+  const attachment = offer?.data?.attachments?.[0]
+  const hasOfferThumbnail =
+    showIcons && attachment && String(attachment.type || "").includes("image") && attachment.url
+
+  const discountInfo = getDiscountMessage(orderItem) || (showDiscountNote && getDiscountNote(orderItem))
+
+  const onQuantityChange = async (q) => {
+    if (updateItemQuantity) await updateItemQuantity(orderItem.id, Number(q))
+  }
+
+  const onRemove = async () => {
+    if (removeFromBasket) await removeFromBasket({ id: orderItem.id })
+  }
+
+  const onUpsell = async (upsellOffer) => {
+    if (swapOffer) await swapOffer(orderItem.id, upsellOffer)
+  }
+
+  const formattedUnitPrice =
+    orderLineItem.unitPriceTotal != null
+      ? formatCurrency(orderLineItem.unitPriceTotal, orderLineItem.currency)
+      : ""
+  const formattedTotal =
+    orderLineItem.lineItemTotal != null
+      ? formatCurrency(orderLineItem.lineItemTotal, orderLineItem.currency)
+      : ""
+
+  return (
+    <div className="cis-item">
+      <div className="cis-item__main">
+        <div className="cis-item__info">
+          {hasOfferThumbnail && (
+            <div className="cis-item__thumb">
+              <img src={attachment.url} alt="" />
+            </div>
+          )}
+          <div className="cis-item__description" data-testid="item-description">
+            <span className="cis-item__name">
+              {product.attributes?.display_name__limio} - {offerAttributes.display_name__limio}
+            </span>
+            {itemInformation && (
+              <span
+                className="cis-item__detail"
+                dangerouslySetInnerHTML={{ __html: parseTemplate(itemInformation, offer) }}
+              />
+            )}
+          </div>
+          {!readOnly && (
+            <button
+              type="button"
+              className="cis-icon-button cis-icon-button--mobile"
+              onClick={onRemove}
+              aria-label={`Remove Item ${offerAttributes.display_name__limio}`}
+            >
+              ×
+            </button>
+          )}
+        </div>
+        <div className="cis-item__controls">
+          {!readOnly && (
+            <QuantitySlider
+              offer={offer}
+              quantity={quantity}
+              onChange={onQuantityChange}
+              disabled={basketLoading}
+              tierLabelTemplate={tierLabelTemplate}
+              tierUnit={tierUnit}
+            />
+          )}
+          <div className="cis-price-block">
+            {discountInfo && (
+              <span className={`cis-price-block__discount ${discountInfo.className || ""}`} data-testid="discount-note">
+                {discountInfo.content}
+              </span>
+            )}
+            <span className="cis-price-block__total" data-testid="item-price">{formattedTotal}</span>
+            {hasMultibuy && formattedUnitPrice && (
+              <span className="cis-price-block__unit" data-testid="item-unit-price">
+                {parseTemplate(perUnitLabel, { formattedPrice: formattedUnitPrice, quantity })}
+              </span>
+            )}
+          </div>
+          {!readOnly && (
+            <button
+              type="button"
+              className="cis-icon-button cis-icon-button--desktop"
+              onClick={onRemove}
+              aria-label={`Remove Item ${offerAttributes.display_name__limio}`}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </div>
+      {addOnItems.map((addOnItem) => (
+        <div
+          key={addOnItem.id}
+          className={`cis-addon-wrapper${hasOfferThumbnail ? " cis-addon-wrapper--indent" : ""}`}
+          data-testid="cart-item"
+        >
+          <AddOnRow
+            addOnItem={addOnItem}
+            addOnInformation={addOnInformation}
+            perUnitLabel={perUnitLabel}
+            readOnly={readOnly}
+            tierLabelTemplate={tierLabelTemplate}
+            tierUnit={tierUnit}
+          />
+        </div>
+      ))}
+      {shouldDisplayUpsellOffers && (
+        <div className={`cis-upsell-wrapper${hasOfferThumbnail ? " cis-upsell-wrapper--indent" : ""}`}>
+          <hr className="cis-separator" />
+          <Upsell
+            offers={orderItem.upsell}
+            currentOffer={orderItem.offer}
+            onUpsell={onUpsell}
+            showUpsellPrice={showUpsellPrice}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CartItem

--- a/components/cart-items-slider/components/QuantitySlider.jsx
+++ b/components/cart-items-slider/components/QuantitySlider.jsx
@@ -1,0 +1,104 @@
+import * as React from "react"
+import {
+  getTierStopsForOffer,
+  findTierStopForQuantity,
+  offerHasVolumePricing,
+  offerHasMultibuy,
+  getOfferQuantityMinMax,
+  formatNumber,
+  parseTemplate
+} from "../helpers"
+
+// Slider replacement for the upstream QuantityControl dropdown.
+// - If the offer has volume-pricing tiers, stops snap to each tier's max (ending_unit)
+//   (or starting_unit for an open-ended final tier).
+// - If the offer has multibuy but no tiers, stops run min..max in increments of 1.
+// - Otherwise the slider does not render.
+function QuantitySlider({ offer, quantity, onChange, disabled, tierLabelTemplate, tierUnit }) {
+  const hasVolume = offerHasVolumePricing(offer)
+  const hasMultibuy = offerHasMultibuy(offer)
+
+  const stops = React.useMemo(() => {
+    if (hasVolume) return getTierStopsForOffer(offer)
+    if (hasMultibuy) {
+      const { min, max } = getOfferQuantityMinMax(offer)
+      const length = Math.max(1, (max || 1) - (min || 1) + 1)
+      return Array.from({ length }, (_, i) => {
+        const value = (min || 1) + i
+        return {
+          id: value,
+          label: formatNumber(value),
+          startingUnit: value,
+          endingUnit: value,
+          isOpenEnded: false
+        }
+      })
+    }
+    return []
+  }, [offer, hasVolume, hasMultibuy])
+
+  const currentIndex = React.useMemo(
+    () => (stops.length ? findTierStopForQuantity(stops, quantity) : -1),
+    [stops, quantity]
+  )
+
+  // Local index so dragging feels responsive; commit to parent on release.
+  const [localIndex, setLocalIndex] = React.useState(currentIndex)
+  React.useEffect(() => {
+    setLocalIndex(currentIndex)
+  }, [currentIndex])
+
+  if (!stops.length) return null
+
+  const activeStop = stops[Math.max(0, localIndex)] || stops[0]
+  const activeLabel = parseTemplate(tierLabelTemplate || "{quantity} {unit}", {
+    quantity: activeStop.label,
+    unit: tierUnit || ""
+  }).trim()
+
+  const commit = (index) => {
+    const stop = stops[index]
+    if (!stop) return
+    if (stop.id !== quantity) onChange(stop.id)
+  }
+
+  return (
+    <div className="cis-slider" data-testid="item-quantity">
+      <div className="cis-slider__track-wrapper">
+        <input
+          type="range"
+          min="0"
+          max={stops.length - 1}
+          step="1"
+          value={Math.max(0, localIndex)}
+          disabled={disabled}
+          onChange={(e) => setLocalIndex(Number(e.target.value))}
+          onMouseUp={(e) => commit(Number(e.currentTarget.value))}
+          onTouchEnd={(e) => commit(Number(e.currentTarget.value))}
+          onKeyUp={(e) => commit(Number(e.currentTarget.value))}
+          className="cis-slider__input"
+          aria-label="Quantity tier"
+          list={`cis-slider-ticks-${stops.length}`}
+        />
+        <datalist id={`cis-slider-ticks-${stops.length}`}>
+          {stops.map((stop, i) => (
+            <option key={stop.id} value={i} label={stop.label} />
+          ))}
+        </datalist>
+        <div className="cis-slider__ticks" aria-hidden="true">
+          {stops.map((stop, i) => (
+            <span
+              key={stop.id}
+              className={`cis-slider__tick${i === localIndex ? " cis-slider__tick--active" : ""}`}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="cis-slider__label" data-testid="item-quantity-label">
+        {activeLabel || activeStop.label}
+      </div>
+    </div>
+  )
+}
+
+export default QuantitySlider

--- a/components/cart-items-slider/components/Upsell.jsx
+++ b/components/cart-items-slider/components/Upsell.jsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { formatCurrency, parseTemplate } from "../helpers"
+
+function Upsell({ offers = [], currentOffer, onUpsell, showUpsellPrice }) {
+  const handleChange = (offerId) => {
+    const offer = offers.find((o) => o.id === offerId)
+    if (offer) onUpsell(offer)
+  }
+
+  return (
+    <div className="cis-upsell" data-testid="upsells">
+      {offers.map((upsellOffer) => {
+        const price = upsellOffer.data?.attributes?.price__limio?.[0]
+        const displayName = upsellOffer.data?.attributes?.upsell_display_name__limio
+        const displayDescription = upsellOffer.data?.attributes?.upsell_display_description__limio
+        const id = upsellOffer.id
+        const selected = currentOffer?.id === id
+        return (
+          <label className="cis-upsell__option" key={id} htmlFor={id}>
+            <input
+              type="radio"
+              id={id}
+              name="cis-upsell"
+              checked={selected}
+              onChange={() => handleChange(id)}
+            />
+            <div className="cis-upsell__text">
+              {displayName && (
+                <span
+                  className="cis-upsell__name"
+                  dangerouslySetInnerHTML={{ __html: parseTemplate(displayName, upsellOffer) }}
+                />
+              )}
+              {displayDescription && (
+                <span
+                  className="cis-upsell__description"
+                  dangerouslySetInnerHTML={{ __html: parseTemplate(displayDescription, upsellOffer) }}
+                />
+              )}
+            </div>
+            {showUpsellPrice && price && (
+              <span className="cis-upsell__price">
+                {formatCurrency(price.value, price.currencyCode)}
+              </span>
+            )}
+          </label>
+        )
+      })}
+    </div>
+  )
+}
+
+export default Upsell

--- a/components/cart-items-slider/helpers.js
+++ b/components/cart-items-slider/helpers.js
@@ -1,0 +1,130 @@
+// Helpers ported from upstream cart-items + QuantityControl.
+// These intentionally avoid depending on @limio/shop or @limio/component-library
+// so the component can run in this demo repo.
+
+export function formatCurrency(value, currency = "USD") {
+  const amount = Number(value)
+  if (Number.isNaN(amount)) return ""
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: amount % 1 === 0 ? 0 : 2
+    }).format(amount)
+  } catch (e) {
+    return `${currency} ${amount}`
+  }
+}
+
+export function formatNumber(value) {
+  const num = Number(value)
+  if (Number.isNaN(num)) return String(value ?? "")
+  return new Intl.NumberFormat().format(num)
+}
+
+// Minimal {placeholder} / {{placeholder}} template — enough for the demo.
+export function parseTemplate(template, variables = {}) {
+  if (!template) return ""
+  return String(template).replace(/\{\{?([a-zA-Z0-9_.]+)\}?\}/g, (match, key) => {
+    const parts = key.split(".")
+    let current = variables
+    for (const part of parts) {
+      if (current == null) return match
+      current = current[part]
+    }
+    return current == null ? "" : String(current)
+  })
+}
+
+// ---- volume-tier helpers (ported from @limio/cart/QuantityControl/helper.ts) ----
+
+function getVolumePrice(offer) {
+  const prices = offer?.data?.attributes?.price__limio
+  if (!Array.isArray(prices)) return null
+  return prices.find((p) => p && p.type === "recurringVolume") || null
+}
+
+export function offerHasVolumePricing(offer) {
+  return Boolean(getVolumePrice(offer))
+}
+
+export function offerHasMultibuy(offer) {
+  return Boolean(offer?.data?.attributes?.allow_multibuy__limio)
+}
+
+export function getOfferQuantityMinMax(offer) {
+  const volumePrice = getVolumePrice(offer)
+  if (volumePrice?.tiers?.length) {
+    const first = volumePrice.tiers[0]
+    const last = volumePrice.tiers[volumePrice.tiers.length - 1]
+    return {
+      min: first.starting_unit,
+      max: last.ending_unit
+    }
+  }
+  const defaults = offer?.data?.attributes?.default_quantity_options__limio || {}
+  return {
+    min: defaults.minimum_quantity || 1,
+    max: defaults.maximum_quantity || 1
+  }
+}
+
+// Returns the list of tiers we'll map slider stops onto.
+// Each stop = { id (= ending_unit, or starting_unit for the open-ended last tier),
+//               label (range string, e.g. "15001 - 30000"),
+//               startingUnit, endingUnit, isOpenEnded }
+export function getTierStopsForOffer(offer) {
+  const volumePrice = getVolumePrice(offer)
+  if (!volumePrice?.tiers?.length) return []
+
+  return volumePrice.tiers.map((tier, index) => {
+    const isLast = index === volumePrice.tiers.length - 1
+    const isOpenEnded = isLast && (tier.ending_unit === undefined || tier.ending_unit === null)
+    const id = isOpenEnded ? tier.starting_unit : tier.ending_unit
+    const label = isOpenEnded
+      ? `${formatNumber(tier.starting_unit)}+`
+      : `${formatNumber(tier.starting_unit)} - ${formatNumber(tier.ending_unit)}`
+    return {
+      id,
+      label,
+      startingUnit: tier.starting_unit,
+      endingUnit: tier.ending_unit,
+      isOpenEnded,
+      price: tier.price,
+      priceFormat: tier.price_format
+    }
+  })
+}
+
+// Given a current quantity, pick the tier stop whose range contains it.
+export function findTierStopForQuantity(stops, quantity) {
+  if (!stops.length) return -1
+  for (let i = 0; i < stops.length; i++) {
+    const stop = stops[i]
+    const withinStart = quantity >= stop.startingUnit
+    const withinEnd = stop.isOpenEnded || quantity <= stop.endingUnit
+    if (withinStart && withinEnd) return i
+  }
+  // fall back to nearest by id
+  if (quantity < stops[0].startingUnit) return 0
+  return stops.length - 1
+}
+
+// ---- discount note helpers ----
+
+export function getDiscountMessage(orderItem) {
+  const orderLineItem = orderItem?.orderLineItem
+  if (orderLineItem?.lineItemDiscount) {
+    return {
+      className: "cis-discount-strike",
+      content: formatCurrency(orderLineItem.lineItemSubtotal, orderLineItem.currency)
+    }
+  }
+  return null
+}
+
+export function getDiscountNote(orderItem) {
+  const note = orderItem?.offer?.data?.attributes?.discount_note__limio
+  if (note) return { className: "", content: note }
+  return null
+}

--- a/components/cart-items-slider/index.css
+++ b/components/cart-items-slider/index.css
@@ -1,0 +1,344 @@
+.cis-root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-family: inherit;
+  color: #1f2937;
+}
+
+.cis-root--empty {
+  align-items: center;
+  padding: 2rem 0;
+}
+
+.cis-empty-text {
+  color: #6b7280;
+  font-size: 1.125rem;
+}
+
+.cis-empty-cta {
+  display: inline-block;
+  margin-top: 0.75rem;
+  padding: 0.625rem 1.25rem;
+  background: #4f46e5;
+  color: #fff;
+  border-radius: 0.375rem;
+  text-decoration: none;
+}
+
+.cis-separator {
+  border: 0;
+  border-top: 1px solid #e5e7eb;
+  margin: 0;
+}
+.cis-separator--section {
+  margin: 2rem 0;
+}
+
+/* ---- cart item ---- */
+.cis-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cis-item__main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .cis-item__main {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.cis-item__info {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.cis-item__thumb {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.cis-item__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cis-item__description {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cis-item__name {
+  font-weight: 600;
+  color: #111827;
+}
+
+.cis-item__detail {
+  color: #6b7280;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.cis-item__controls {
+  margin-left: auto;
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+}
+
+@media (min-width: 640px) {
+  .cis-item__controls {
+    align-items: flex-start;
+  }
+}
+
+/* ---- price block ---- */
+.cis-price-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  min-width: 6rem;
+}
+
+.cis-price-block__discount {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+.cis-discount-strike {
+  text-decoration: line-through;
+}
+
+.cis-price-block__total {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.cis-price-block__unit {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+/* ---- icon button ---- */
+.cis-icon-button {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: #9ca3af;
+  padding: 0.25rem 0.5rem;
+}
+.cis-icon-button:hover { color: #4b5563; }
+
+.cis-icon-button--mobile {
+  margin-left: auto;
+  display: inline-flex;
+}
+.cis-icon-button--desktop {
+  display: none;
+}
+@media (min-width: 640px) {
+  .cis-icon-button--mobile { display: none; }
+  .cis-icon-button--desktop { display: inline-flex; }
+}
+
+/* ---- add-on row ---- */
+.cis-addon-wrapper {
+  display: flex;
+}
+.cis-addon-wrapper--indent { padding-left: 4rem; }
+
+.cis-addon-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .cis-addon-row { flex-direction: row; }
+}
+
+.cis-addon-row__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cis-addon-row__name {
+  font-weight: 600;
+  color: #111827;
+}
+
+.cis-addon-row__description {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.cis-addon-row__controls {
+  margin-left: auto;
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+}
+
+/* ---- upsell ---- */
+.cis-upsell-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.cis-upsell-wrapper--indent { padding-left: 4rem; }
+
+.cis-upsell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cis-upsell__option {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  cursor: pointer;
+  padding-right: calc(2rem + 38px);
+}
+
+.cis-upsell__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.cis-upsell__name {
+  color: #111827;
+}
+
+.cis-upsell__description {
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.cis-upsell__price {
+  margin-left: auto;
+  font-weight: 600;
+  color: #374151;
+  font-size: 0.875rem;
+}
+
+/* ---- banner ---- */
+.cis-banner {
+  padding: 0.75rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+}
+.cis-banner--error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+/* ---- quantity slider ---- */
+.cis-slider {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 16rem;
+}
+
+.cis-slider__track-wrapper {
+  position: relative;
+  padding: 0.25rem 0 0.75rem;
+}
+
+.cis-slider__input {
+  width: 100%;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  position: relative;
+  z-index: 2;
+}
+
+.cis-slider__input::-webkit-slider-runnable-track {
+  height: 4px;
+  background: #e5e7eb;
+  border-radius: 9999px;
+}
+
+.cis-slider__input::-moz-range-track {
+  height: 4px;
+  background: #e5e7eb;
+  border-radius: 9999px;
+}
+
+.cis-slider__input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background: #4f46e5;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  margin-top: -8px;
+  cursor: pointer;
+}
+
+.cis-slider__input::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background: #4f46e5;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+}
+
+.cis-slider__input:disabled::-webkit-slider-thumb { background: #9ca3af; cursor: not-allowed; }
+.cis-slider__input:disabled::-moz-range-thumb { background: #9ca3af; cursor: not-allowed; }
+
+.cis-slider__ticks {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  top: calc(0.25rem + 1px);
+  display: flex;
+  justify-content: space-between;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.cis-slider__tick {
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+  background: #fff;
+  border: 2px solid #c7d2fe;
+}
+
+.cis-slider__tick--active {
+  border-color: #4f46e5;
+  background: #4f46e5;
+}
+
+.cis-slider__label {
+  text-align: center;
+  font-size: 0.875rem;
+  color: #374151;
+  font-weight: 500;
+}

--- a/components/cart-items-slider/index.js
+++ b/components/cart-items-slider/index.js
@@ -1,0 +1,77 @@
+import * as React from "react"
+import { useBasket } from "@limio/sdk"
+import { useCheckout } from "@limio/internal-checkout-sdk"
+import CartItem from "./components/CartItem"
+import "./index.css"
+
+function CartItemsSlider(props) {
+  const {
+    showIcons = true,
+    offerInformation = "{{data.attributes.display_description__limio}}",
+    lineItemInformation = "",
+    addOnInformation = "{{data.attributes.description__limio}}",
+    perUnitLabel = "{quantity} x {formattedPrice} each",
+    tierLabelTemplate = "{quantity} {unit}",
+    tierUnit = "",
+    emptyText = "Your cart is empty, view offers to get started",
+    emptyCta = "See offers",
+    emptyUrl = "/default",
+    displayUpsellOffers = false,
+    showUpsellPrice = true,
+    readOnly = false,
+    showDiscountNote = false
+  } = props
+
+  const componentProps = {
+    showIcons,
+    offerInformation,
+    lineItemInformation,
+    addOnInformation,
+    perUnitLabel,
+    tierLabelTemplate,
+    tierUnit,
+    displayUpsellOffers,
+    showUpsellPrice,
+    readOnly,
+    showDiscountNote
+  }
+
+  const basket = useBasket() || {}
+  const { useCheckoutSelector } = useCheckout({ redirectOnFailure: false }) || {}
+
+  // Prefer basketItems (overridable via LimioProvider value), fall back to
+  // checkout order.orderItems which is what the upstream cart-items reads.
+  const orderItems =
+    (Array.isArray(basket.basketItems) && basket.basketItems.length && basket.basketItems) ||
+    (useCheckoutSelector && useCheckoutSelector((s) => s.order?.orderItems)) ||
+    []
+
+  const parents = orderItems.filter((i) => !i.parentId)
+
+  if (!parents.length) {
+    return (
+      <div className="cis-root cis-root--empty">
+        <p className="cis-empty-text">{emptyText}</p>
+        {emptyCta && (
+          <a className="cis-empty-cta" href={emptyUrl}>{emptyCta}</a>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="cis-root">
+      {parents.map((orderItem, index) => {
+        const addOns = orderItems.filter((i) => i.parentId === orderItem.id)
+        return (
+          <div key={orderItem.id || index}>
+            <CartItem orderItem={orderItem} componentProps={componentProps} addOnItems={addOns} />
+            <hr className="cis-separator cis-separator--section" />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default CartItemsSlider

--- a/components/cart-items-slider/package.json
+++ b/components/cart-items-slider/package.json
@@ -1,0 +1,103 @@
+{
+  "name": "component-cart-items-slider",
+  "version": "1.0.0",
+  "description": "Cart Items with a volume-tier slider quantity picker",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "showIcons",
+      "label": "Show offer icons",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "offerInformation",
+      "label": "Offer Additional Information",
+      "type": "richtext",
+      "default": "{{data.attributes.display_description__limio}}"
+    },
+    {
+      "id": "lineItemInformation",
+      "label": "Line Item Additional Information",
+      "type": "richtext",
+      "default": ""
+    },
+    {
+      "id": "addOnInformation",
+      "label": "AddOn Additional Information",
+      "type": "richtext",
+      "default": "{{data.attributes.description__limio}}"
+    },
+    {
+      "id": "perUnitLabel",
+      "label": "Unit price label when multibuy is available",
+      "type": "string",
+      "default": "{quantity} x {formattedPrice} each"
+    },
+    {
+      "id": "tierLabelTemplate",
+      "label": "Slider tier label (supports {quantity} and {unit})",
+      "type": "string",
+      "default": "{quantity} {unit}"
+    },
+    {
+      "id": "tierUnit",
+      "label": "Unit of measurement shown under the slider",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "id": "emptyText",
+      "label": "Message when cart is empty",
+      "type": "string",
+      "default": "Your cart is empty, view offers to get started"
+    },
+    {
+      "id": "emptyCta",
+      "label": "CTA label when cart is empty",
+      "type": "string",
+      "default": "See offers"
+    },
+    {
+      "id": "emptyUrl",
+      "label": "URL to direct users to when cart is empty",
+      "type": "string",
+      "default": "/default"
+    },
+    {
+      "id": "displayUpsellOffers",
+      "label": "Display upsell offers",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "id": "showUpsellPrice",
+      "label": "Show price in upsell offers",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "readOnly",
+      "label": "Show component in read-only mode?",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "id": "showDiscountNote",
+      "label": "Show discount note",
+      "type": "boolean",
+      "default": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New `cart-items-slider` component: a port of the upstream [cart-items](https://github.com/innovate42/innovate42-service-template/tree/develop/services/components/cart-items) with the quantity dropdown replaced by a volume-tier slider.
- Slider stops map to each `recurringVolume` tier's `ending_unit` (e.g. 15,000 → 30,000 → 60,000…) and call the same `updateItemQuantity(id, value)` callback the dropdown uses, so volume/pricing logic is unchanged.
- Label under the slider is configurable via two new `limioProps`:
  - `tierLabelTemplate` (default `"{quantity} {unit}"`)
  - `tierUnit` (e.g. `"in monthly expenses"`)
- Storybook: new `Cart Items Slider` story with a mock 6-tier offer matching typical SaaS volume pricing.
- Extended the Storybook `useBasket` mock with `swapOffer` / `removeFromBasket` / `updateItemQuantity` / `basketLoading` so the slider + remove actions render in stories (backwards-compatible — existing stories unaffected).

## Test plan
- [ ] Merge, wait for CI mirror to CodeCommit, then check the new component shows up in the Limio admin at https://saas-dev.prod.limio.com
- [ ] Add `cart-items-slider` to a checkout page against an offer with volume pricing
- [ ] Confirm slider ticks match the offer's volume-tier upper bounds
- [ ] Confirm sliding to a new tick updates the line-item price the same way the dropdown does
- [ ] Confirm fallback: offers without volume pricing / multibuy hide the slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)