### PR TITLE
offers-propelus: gating screen fills viewport height

### DIFF
--- a/components/offers-propelus/index.js
+++ b/components/offers-propelus/index.js
@@ -239,7 +239,11 @@ export const OffersPropelus = () => {
                         <Box
                             sx={{
                                 backgroundColor: themeSet.gatingBg,
-                                py: { xs: 8, md: 12 },
+                                minHeight: "calc(100vh - 60px)",
+                                display: "flex",
+                                flexDirection: "column",
+                                alignItems: "center",
+                                justifyContent: "center",
                                 px: { xs: 3, md: 4 },
                                 textAlign: "center",
                             }}
@@ -399,15 +403,11 @@ export const OffersPropelus = () => {
                                         fontFamily: "Inter, sans-serif",
                                         lineHeight: 1.6,
                                         m: 0,
-<<<<<<< HEAD
                                         mb: 2,
-=======
->>>>>>> origin/saas-dev
                                     }}
                                 >
                                     {subheading}
                                 </Box>
-<<<<<<< HEAD
                                 <Box
                                     component="button"
                                     onClick={handleReset}
@@ -426,8 +426,6 @@ export const OffersPropelus = () => {
                                 >
                                     Choose a different state or profession
                                 </Box>
-=======
->>>>>>> origin/saas-dev
                             </Box>
 
                             {showGroupedOffers ? (


### PR DESCRIPTION
## Summary

- Gating screen was sitting awkwardly at the top of the page with empty space below
- Added `minHeight: calc(100vh - 60px)` and flex centering so it fills the full space between nav and footer
- Content (heading, subtitle, dropdowns) is now vertically centered in the available space

## Test plan

- [ ] Visit the page — gating screen should fill the viewport, not hug the top
- [ ] Content should be vertically centered between the nav bar and the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)