### PR TITLE
cancel-survey-radio-button-material: new MUI component

### DIFF
--- a/component-playground/src/stories/CancelSurveyRadioButton.stories.js
+++ b/component-playground/src/stories/CancelSurveyRadioButton.stories.js
@@ -1,0 +1,53 @@
+import React from "react"
+import { LimioProvider, ComponentContext } from "@limio/sdk"
+import CancelSurveyRadioButton from "../../../components/cancel-survey-radio-button-create-basket/index"
+
+function withContext(Story, context) {
+  return (
+    <LimioProvider value={{}}>
+      <ComponentContext.Provider value={context.args}>
+        <Story />
+      </ComponentContext.Provider>
+    </LimioProvider>
+  )
+}
+
+const defaultArgs = {
+  title: "We're sorry to see you go",
+  subtitle: "Before you cancel, please let us know why you're leaving. Your feedback helps us improve.",
+  reasonsHeading: "Why are you cancelling?",
+  reasons: [
+    { label: "Too expensive", value: "too_expensive", url: "/cancel/confirm" },
+    { label: "Not using it enough", value: "not_using", url: "/cancel/confirm" },
+    { label: "Missing features I need", value: "missing_features", url: "/cancel/confirm" },
+    { label: "Switching to a competitor", value: "switching", url: "/cancel/confirm" },
+  ],
+  showOtherReason: true,
+  otherReasonLabel: "Other reason",
+  otherReasonValue: "other",
+  otherReasonUrl: "/cancel/confirm",
+  captureOtherReasonText: true,
+  otherReasonCaptureTextLabel: "Please tell us more",
+  showImage: false,
+  imageUrl: "",
+  cancelButtonText: "Cancel my subscription",
+  keepSubscriptionButtonText: "Keep my subscription",
+  keepSubscriptionUrl: "/account",
+}
+
+export default {
+  title: "Cancel Survey Radio Button",
+  component: CancelSurveyRadioButton,
+  parameters: { layout: "fullscreen" },
+  decorators: [withContext],
+}
+
+export const Default = { args: { ...defaultArgs } }
+
+export const WithImage = {
+  args: {
+    ...defaultArgs,
+    showImage: true,
+    imageUrl: "https://placehold.co/350x280",
+  },
+}

--- a/component-playground/src/stories/CancelSurveyRadioButtonMaterial.stories.js
+++ b/component-playground/src/stories/CancelSurveyRadioButtonMaterial.stories.js
@@ -1,0 +1,63 @@
+import React from "react"
+import { LimioProvider, ComponentContext } from "@limio/sdk"
+import CancelSurveyRadioButtonMaterial from "../../../components/cancel-survey-radio-button-material/index"
+
+function withContext(Story, context) {
+    return (
+        <LimioProvider value={{}}>
+            <ComponentContext.Provider value={context.args}>
+                <Story />
+            </ComponentContext.Provider>
+        </LimioProvider>
+    )
+}
+
+const defaultArgs = {
+    title: "Before you go",
+    subtitle: "Please tell us why you want to cancel your subscription",
+    reasonsHeading: "Why would you like to cancel your subscription?",
+    reasons: [
+        { label: "This subscription is too expensive", value: "too_expensive", url: "/expensive", createBasket__limio_boolean: false },
+        { label: "I have too much content", value: "too_much", url: "/quantity", createBasket__limio_boolean: false },
+        { label: "I did not like the membership benefits", value: "dislike_benefits", url: "/dislike", createBasket__limio_boolean: false },
+        { label: "I found an alternative", value: "found_alternative", url: "/alternative", createBasket__limio_boolean: false },
+        { label: "I'd rather not say", value: "no_reason", url: "/help", createBasket__limio_boolean: false },
+    ],
+    showOtherReason: true,
+    otherReasonLabel: "Other",
+    otherReasonValue: "other",
+    otherReasonUrl: "/other",
+    captureOtherReasonText: true,
+    otherReasonCaptureTextLabel: "Tell us more (optional)",
+    showImage: true,
+    imageUrl: "https://custom-images.strikinglycdn.com/res/hrscywv4p/image/upload/c_limit,fl_lossy,h_9000,w_1200,f_auto,q_auto/1156184/860406_495342.png",
+    cancelButtonText: "Continue to cancel",
+    keepSubscriptionButtonText: "Keep my subscription",
+    keepSubscriptionUrl: "https://limio.com",
+    themeColor: "orange",
+}
+
+export default {
+    title: "Cancel Survey Radio Button Material",
+    component: CancelSurveyRadioButtonMaterial,
+    parameters: { layout: "fullscreen" },
+    decorators: [withContext],
+}
+
+export const Default = { args: { ...defaultArgs } }
+
+export const NoImage = {
+    args: { ...defaultArgs, showImage: false },
+}
+
+export const BlueTheme = {
+    args: { ...defaultArgs, themeColor: "blue" },
+}
+
+export const GreenTheme = {
+    args: { ...defaultArgs, themeColor: "green" },
+}
+
+export const NoOtherReason = {
+    args: { ...defaultArgs, showOtherReason: false, captureOtherReasonText: false },
+}

--- a/components/cancel-survey-radio-button-create-basket/index.css
+++ b/components/cancel-survey-radio-button-create-basket/index.css
@@ -1,5 +1,15 @@
+@import '@fontsource/inter/400.css';
+@import '@fontsource/inter/500.css';
+@import '@fontsource/inter/600.css';
+@import '@fontsource/inter/700.css';
+@import '@fontsource/inter/800.css';
+
 :root {
-  --color-black: #121212;
+  --font-family: 'Inter', 'system-ui', 'Helvetica Neue', Arial, sans-serif;
+  --color-heading: #111827;
+  --color-body: #6B7280;
+  --color-text: #374151;
+  --color-divider: #E5E7EB;
 }
 
 em {
@@ -10,6 +20,9 @@ em {
   padding: 3rem 1rem;
   margin: 0 auto;
   max-width: 900px;
+  font-family: var(--font-family);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .contentWrapper {
@@ -22,42 +35,49 @@ em {
 }
 
 .contentWrapperRight {
-  padding-left: 1rem;
+  padding-left: 2rem;
 }
 
+/* h1 — matches offer-cards-material main heading */
 .heading {
-  padding-bottom: 1.5rem;
-  font-size: 1.8rem;
+  margin: 0 0 1.25rem 0;
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--color-heading);
+  font-family: var(--font-family);
+  text-align: left;
 }
 
-.heading,
+/* subtitle — matches offer-cards-material subheading */
 .paragraph {
-  margin: 0 auto;
-  color: var(--color-black);
-  text-align: center;
-}
-
-.paragraph {
-  padding-bottom: 2.5rem;
-  font-size: 1.2rem;
-  line-height: 1.39;
+  margin: 0 0 2.5rem 0;
+  font-size: 1.125rem;
+  font-weight: 300;
+  color: var(--color-body);
+  line-height: 1.6;
+  font-family: var(--font-family);
+  text-align: left;
 }
 
 .reasonList {
   padding-bottom: 1.1rem;
 }
 
+/* h2 — section heading */
 .reasonListHeading {
-  margin: 0;
-  padding-bottom: 1.5rem;
-  font-size: 1.1rem;
-  line-height: 1.39;
-  color: var(--color-black);
+  margin: 0 0 1.25rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-heading);
+  font-family: var(--font-family);
 }
 
 .reasonListItem {
   display: flex;
-  padding-bottom: 1rem;
+  margin-bottom: 0.875rem;
   align-items: center;
 }
 
@@ -65,10 +85,13 @@ em {
   display: block;
   width: 100%;
   margin: 0;
-  padding-left: 1rem;
-  font-size: 1rem;
-  color: var(--color-black);
+  padding-left: 0.75rem;
+  font-size: 0.9375rem;
+  font-weight: 400;
+  color: var(--color-text);
+  font-family: var(--font-family);
   cursor: pointer;
+  line-height: 1.5;
 }
 
 .reasonImage {
@@ -76,69 +99,60 @@ em {
   margin: 0;
   padding: 0;
   max-width: 350px;
+  border-radius: 8px;
 }
 
-.textboxLabel {
-  padding-bottom: 0.5rem;
-  font-weight: 500;
-}
-
-.textbox,
 .textboxLabel {
   display: block;
-  color: var(--color-black);
+  margin-bottom: 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--color-heading);
+  font-family: var(--font-family);
+}
+
+.textbox {
+  display: block;
+  font-family: var(--font-family);
+  font-size: 0.9375rem;
+  color: var(--color-text);
 }
 
 .divider {
-  margin: 0;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-  border-top: 1px solid #d7d7d7 !important;
+  margin: 1rem 0;
   border: none;
+  border-top: 1px solid var(--color-divider);
 }
 
 .list {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .listItem {
   display: block;
-  padding-right: 1rem;
 }
 
-.button {
-  display: block;
-  width: 100%;
-}
-
-@media (min-width: 30rem) {
+@media (max-width: 640px) {
   .heading {
-    font-size: 2.5rem;
+    font-size: 1.75rem;
   }
 
-  .heading,
-  .paragraph {
-    margin: 0;
-    text-align: left;
+  .contentWrapper {
+    flex-wrap: wrap;
   }
-}
 
-@media (max-width: 30rem) {
+  .contentWrapperRight {
+    display: none;
+  }
+
   .list {
     flex-direction: column;
   }
 
   .listItem {
     width: 100%;
-    padding-bottom: 1rem;
-    padding-right: 0;
-  }
-}
-
-@media (max-width: 50rem) {
-  .hide {
-    display: none;
   }
 }

--- a/components/cancel-survey-radio-button-material/componentStaticProps.js
+++ b/components/cancel-survey-radio-button-material/componentStaticProps.js
@@ -1,0 +1,8 @@
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+import packageData from "./package.json"
+
+const defaultComponentProps = getPropsFromPackageJson(packageData)
+
+export function useStaticProps() {
+    return useComponentProps(defaultComponentProps)
+}

--- a/components/cancel-survey-radio-button-material/index.js
+++ b/components/cancel-survey-radio-button-material/index.js
@@ -1,0 +1,339 @@
+import React, { useState } from "react"
+import { sanitiseHTML, useBasket } from "@limio/sdk"
+import { createTheme, ThemeProvider, StyledEngineProvider } from "@mui/material/styles"
+import { CssBaseline, Box, Typography, Button, Radio, FormControlLabel, RadioGroup, TextField, Divider } from "@mui/material"
+import "@fontsource/inter/400.css"
+import "@fontsource/inter/500.css"
+import "@fontsource/inter/600.css"
+import "@fontsource/inter/700.css"
+import "@fontsource/inter/800.css"
+
+const themeStyles = {
+    orange: {
+        primary: "#E16A00",
+        radioChecked: "#E16A00",
+        buttonBg: "#E16A00",
+        buttonHover: "#C45E00",
+    },
+    blue: {
+        primary: "#005C99",
+        radioChecked: "#005C99",
+        buttonBg: "#005C99",
+        buttonHover: "#004A80",
+    },
+    green: {
+        primary: "#2E7D32",
+        radioChecked: "#2E7D32",
+        buttonBg: "#2E7D32",
+        buttonHover: "#1B5E20",
+    },
+    red: {
+        primary: "#C62828",
+        radioChecked: "#C62828",
+        buttonBg: "#C62828",
+        buttonHover: "#8B0000",
+    },
+    black: {
+        primary: "#333333",
+        radioChecked: "#333333",
+        buttonBg: "#333333",
+        buttonHover: "#111111",
+    },
+}
+
+const muiTheme = createTheme({
+    typography: {
+        fontFamily: `'Inter', 'system-ui', 'Helvetica Neue', Arial, sans-serif`,
+    },
+})
+
+const CancelSurveyRadioButtonMaterial = ({
+    title,
+    subtitle,
+    reasonsHeading,
+    reasons,
+    otherReasonLabel,
+    otherReasonValue,
+    otherReasonUrl,
+    showOtherReason,
+    captureOtherReasonText,
+    otherReasonCaptureTextLabel,
+    showImage,
+    imageUrl,
+    cancelButtonText,
+    keepSubscriptionButtonText,
+    keepSubscriptionUrl,
+    themeColor = "orange",
+}) => {
+    const { initiateCheckout } = useBasket()
+    const [selectedReason, setSelectedReason] = useState(null)
+    const [otherReasonText, setOtherReasonText] = useState("")
+
+    const ts = themeStyles[themeColor] || themeStyles.orange
+
+    const otherReason = {
+        label: otherReasonLabel,
+        value: otherReasonValue,
+        url: otherReasonUrl,
+    }
+
+    const allReasons = showOtherReason ? [...(reasons || []), otherReason] : (reasons || [])
+
+    const onCancel = async () => {
+        const subId = new URLSearchParams(window.location.search).get("subId")
+        const url = new URL(selectedReason.url, window.location.origin)
+        url.searchParams.set("subId", subId)
+        url.searchParams.set("reason", selectedReason.value)
+
+        if (selectedReason?.createBasket__limio_boolean) {
+            const basket = await initiateCheckout({
+                order: {
+                    order_type: "update_subscription",
+                    forSubscription: { id: subId },
+                },
+            })
+            url.searchParams.set("basket", basket.order.checkoutId)
+        }
+
+        window.location.assign(url.toString())
+    }
+
+    const onKeepSubscription = () => {
+        window.location.assign(keepSubscriptionUrl)
+    }
+
+    const radioSx = {
+        color: "#D1D5DB",
+        "&.Mui-checked": { color: ts.radioChecked },
+        padding: "6px 9px",
+    }
+
+    const labelTypographySx = {
+        fontSize: "0.9375rem",
+        fontWeight: 400,
+        color: "#374151",
+        fontFamily: "Inter, sans-serif",
+        lineHeight: 1.5,
+    }
+
+    return (
+        <StyledEngineProvider injectFirst>
+            <ThemeProvider theme={muiTheme}>
+                <CssBaseline />
+                <Box
+                    sx={{
+                        py: { xs: 6, md: 10 },
+                        px: { xs: 3, md: 6 },
+                        maxWidth: "900px",
+                        margin: "0 auto",
+                        fontFamily: "Inter, sans-serif",
+                        WebkitFontSmoothing: "antialiased",
+                        MozOsxFontSmoothing: "grayscale",
+                    }}
+                >
+                    {/* Two-column layout */}
+                    <Box sx={{ display: "flex", gap: 4, flexWrap: { xs: "wrap", md: "nowrap" } }}>
+                        {/* Left: form content */}
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                            {/* h1 */}
+                            <Typography
+                                component="h1"
+                                sx={{
+                                    fontSize: "2.25rem",
+                                    fontWeight: 800,
+                                    letterSpacing: "-0.01em",
+                                    lineHeight: 1.2,
+                                    color: "#111827",
+                                    fontFamily: "Inter, sans-serif",
+                                    mb: 2,
+                                    textAlign: "left",
+                                }}
+                            >
+                                {title}
+                            </Typography>
+
+                            {/* Subtitle */}
+                            <Typography
+                                component="p"
+                                sx={{
+                                    fontSize: "1.125rem",
+                                    fontWeight: 300,
+                                    color: "#6B7280",
+                                    lineHeight: 1.6,
+                                    fontFamily: "Inter, sans-serif",
+                                    mb: 4,
+                                    textAlign: "left",
+                                }}
+                                dangerouslySetInnerHTML={{ __html: sanitiseHTML(subtitle) }}
+                            />
+
+                            {/* h2 — reasons heading */}
+                            <Typography
+                                component="h2"
+                                sx={{
+                                    fontSize: "1.125rem",
+                                    fontWeight: 600,
+                                    color: "#111827",
+                                    fontFamily: "Inter, sans-serif",
+                                    mb: 2,
+                                    textAlign: "left",
+                                }}
+                                dangerouslySetInnerHTML={{ __html: sanitiseHTML(reasonsHeading) }}
+                            />
+
+                            {/* Radio group */}
+                            <RadioGroup
+                                value={selectedReason?.value || ""}
+                                onChange={(e) => {
+                                    const found = allReasons.find((r) => r.value === e.target.value)
+                                    setSelectedReason(found || null)
+                                }}
+                            >
+                                {allReasons.map((r) => (
+                                    <FormControlLabel
+                                        key={r.value}
+                                        value={r.value}
+                                        control={<Radio sx={radioSx} />}
+                                        label={
+                                            <Typography sx={labelTypographySx}>{r.label}</Typography>
+                                        }
+                                        sx={{ mb: 0.25, alignItems: "center" }}
+                                    />
+                                ))}
+                            </RadioGroup>
+
+                            {/* Other reason text capture */}
+                            {captureOtherReasonText &&
+                                selectedReason?.value === otherReason.value && (
+                                    <Box sx={{ mt: 2 }}>
+                                        <Typography
+                                            component="label"
+                                            htmlFor="other-reason-text"
+                                            sx={{
+                                                display: "block",
+                                                fontSize: "0.9375rem",
+                                                fontWeight: 500,
+                                                color: "#111827",
+                                                fontFamily: "Inter, sans-serif",
+                                                mb: 1,
+                                            }}
+                                        >
+                                            {otherReasonCaptureTextLabel}
+                                        </Typography>
+                                        <TextField
+                                            id="other-reason-text"
+                                            multiline
+                                            rows={4}
+                                            fullWidth
+                                            value={otherReasonText}
+                                            onChange={(e) => setOtherReasonText(e.target.value)}
+                                            sx={{
+                                                "& .MuiOutlinedInput-root": {
+                                                    fontSize: "0.9375rem",
+                                                    fontFamily: "Inter, sans-serif",
+                                                    borderRadius: "8px",
+                                                    "& fieldset": { borderColor: "#D1D5DB" },
+                                                    "&:hover fieldset": { borderColor: "#9CA3AF" },
+                                                    "&.Mui-focused fieldset": {
+                                                        borderColor: ts.primary,
+                                                    },
+                                                },
+                                            }}
+                                        />
+                                    </Box>
+                                )}
+                        </Box>
+
+                        {/* Right: image */}
+                        {showImage && imageUrl && (
+                            <Box
+                                sx={{
+                                    flexShrink: 0,
+                                    display: { xs: "none", sm: "flex" },
+                                    alignItems: "flex-start",
+                                    pt: 1,
+                                }}
+                            >
+                                <Box
+                                    component="img"
+                                    src={imageUrl}
+                                    role="presentation"
+                                    sx={{
+                                        maxWidth: "320px",
+                                        width: "100%",
+                                        borderRadius: "12px",
+                                        objectFit: "cover",
+                                    }}
+                                />
+                            </Box>
+                        )}
+                    </Box>
+
+                    <Divider sx={{ my: 4, borderColor: "#E5E7EB" }} />
+
+                    {/* Action buttons */}
+                    <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+                        {/* Keep subscription — primary action */}
+                        <Button
+                            onClick={onKeepSubscription}
+                            variant="contained"
+                            sx={{
+                                backgroundColor: `${ts.buttonBg} !important`,
+                                color: "#FFFFFF !important",
+                                fontWeight: "600 !important",
+                                fontSize: "0.9375rem !important",
+                                fontFamily: "'Inter', sans-serif !important",
+                                textTransform: "none !important",
+                                borderRadius: "8px !important",
+                                px: "24px !important",
+                                py: "10px !important",
+                                boxShadow: "none !important",
+                                letterSpacing: "0 !important",
+                                "&:hover": {
+                                    backgroundColor: `${ts.buttonHover} !important`,
+                                    boxShadow: "none !important",
+                                },
+                            }}
+                        >
+                            {keepSubscriptionButtonText}
+                        </Button>
+
+                        {/* Cancel — secondary / destructive */}
+                        <Button
+                            onClick={onCancel}
+                            disabled={selectedReason == null}
+                            variant="outlined"
+                            sx={{
+                                backgroundColor: "#FFFFFF !important",
+                                border: "1px solid #D1D5DB !important",
+                                color: "#374151 !important",
+                                fontWeight: "500 !important",
+                                fontSize: "0.9375rem !important",
+                                fontFamily: "'Inter', sans-serif !important",
+                                textTransform: "none !important",
+                                borderRadius: "8px !important",
+                                px: "24px !important",
+                                py: "10px !important",
+                                boxShadow: "none !important",
+                                letterSpacing: "0 !important",
+                                "&:hover": {
+                                    backgroundColor: "#F9FAFB !important",
+                                    borderColor: "#9CA3AF !important",
+                                },
+                                "&.Mui-disabled": {
+                                    backgroundColor: "#F3F4F6 !important",
+                                    color: "#9CA3AF !important",
+                                    borderColor: "#E5E7EB !important",
+                                },
+                            }}
+                        >
+                            {cancelButtonText}
+                        </Button>
+                    </Box>
+                </Box>
+            </ThemeProvider>
+        </StyledEngineProvider>
+    )
+}
+
+export default CancelSurveyRadioButtonMaterial

--- a/components/cancel-survey-radio-button-material/package.json
+++ b/components/cancel-survey-radio-button-material/package.json
@@ -1,0 +1,183 @@
+{
+  "name": "@limio/component-cancel-survey-radio-button-material",
+  "version": "1.0.0",
+  "description": "Material-styled cancel survey with radio buttons",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@emotion/react": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
+    "@fontsource/inter": "^4.5.0",
+    "@mui/material": "5.16.12"
+  },
+  "peerDependencies": {
+    "@limio/sdk": "workspace:^",
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "title",
+      "label": "Title",
+      "type": "string",
+      "default": "Before you go"
+    },
+    {
+      "id": "subtitle",
+      "label": "Subtitle",
+      "type": "string",
+      "default": "Please tell us why you want to cancel your subscription"
+    },
+    {
+      "id": "reasonsHeading",
+      "label": "Reasons heading",
+      "type": "richtext",
+      "default": "Why would you like to cancel your subscription?"
+    },
+    {
+      "id": "reasons",
+      "label": "Reasons",
+      "type": "list",
+      "fields": {
+        "label": {
+          "id": "label",
+          "label": "Label",
+          "type": "string"
+        },
+        "value": {
+          "id": "value",
+          "label": "Value",
+          "type": "string"
+        },
+        "url": {
+          "id": "url",
+          "label": "Url",
+          "type": "string"
+        },
+        "createBasket__limio_boolean": {
+          "id": "createBasket__limio_boolean",
+          "label": "Create update subscription basket",
+          "type": "boolean"
+        }
+      },
+      "default": [
+        {
+          "label": "This subscription is too expensive",
+          "value": "too_expensive",
+          "url": "/expensive",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "I have too much content",
+          "value": "too_much",
+          "url": "/quantity",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "I did not like the membership benefits",
+          "value": "dislike_benefits",
+          "url": "/dislike",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "I found an alternative",
+          "value": "found_alternative",
+          "url": "/alternative",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "I'd rather not say",
+          "value": "no_reason",
+          "url": "/help",
+          "createBasket__limio_boolean": false
+        }
+      ]
+    },
+    {
+      "id": "otherReasonLabel",
+      "label": "Other reason label",
+      "type": "string",
+      "default": "Other"
+    },
+    {
+      "id": "otherReasonValue",
+      "label": "Other reason value",
+      "type": "string",
+      "default": "other"
+    },
+    {
+      "id": "otherReasonUrl",
+      "label": "Other reason url",
+      "type": "string",
+      "default": "/other"
+    },
+    {
+      "id": "showOtherReason",
+      "label": "Show other reason",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "captureOtherReasonText",
+      "label": "Capture other reason text",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "otherReasonCaptureTextLabel",
+      "label": "Other reason capture text label",
+      "type": "string",
+      "default": "Tell us more (optional)"
+    },
+    {
+      "id": "showImage",
+      "label": "Show image",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "imageUrl",
+      "label": "Image URL",
+      "type": "string",
+      "default": "https://custom-images.strikinglycdn.com/res/hrscywv4p/image/upload/c_limit,fl_lossy,h_9000,w_1200,f_auto,q_auto/1156184/860406_495342.png"
+    },
+    {
+      "id": "cancelButtonText",
+      "label": "Cancel button text",
+      "type": "string",
+      "default": "Continue to cancel"
+    },
+    {
+      "id": "keepSubscriptionButtonText",
+      "label": "Keep subscription button text",
+      "type": "string",
+      "default": "Keep my subscription"
+    },
+    {
+      "id": "keepSubscriptionUrl",
+      "label": "Keep subscription URL",
+      "type": "string",
+      "default": "https://limio.com"
+    },
+    {
+      "id": "themeColor",
+      "label": "Theme colour",
+      "type": "picklist",
+      "options": [
+        { "id": "orange", "label": "Orange", "value": "orange" },
+        { "id": "blue", "label": "Blue", "value": "blue" },
+        { "id": "green", "label": "Green", "value": "green" },
+        { "id": "red", "label": "Red", "value": "red" },
+        { "id": "black", "label": "Black", "value": "black" }
+      ],
+      "default": "orange"
+    }
+  ],
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ]
+}


### PR DESCRIPTION
## Summary

- New `cancel-survey-radio-button-material` component built with MUI, matching the visual language of `offer-cards-material`
- Inter font (400–800 weights), h1/h2 typography, and colour palette (`#111827`, `#6B7280`, `#374151`) aligned to the material design system
- Always left-aligned; `themeColor` picklist (orange/blue/green/red/black) mirrors the offer-cards-material prop
- Same props and basket/URL logic as the original `cancel-survey-radio-button-create-basket`
- CSS of original component also updated to match the same typographic style
- Storybook stories added for both components (Default, NoImage, BlueTheme, GreenTheme, NoOtherReason)

## Test plan

- [ ] Run `yarn limio` in `component-playground/` and open http://localhost:6006
- [ ] Check **Cancel Survey Radio Button Material → Default** — Inter font, left-aligned h1/h2, orange radio + buttons
- [ ] Switch `themeColor` to blue/green/red/black and confirm accent colours update
- [ ] Select a reason and confirm the cancel button becomes enabled
- [ ] Select "Other" and confirm the freetext field appears
- [ ] Toggle `showImage` on/off and confirm image column shows/hides
- [ ] Confirm the original **Cancel Survey Radio Button → Default** story also renders with updated typography

🤖 Generated with [Claude Code](https://claude.com/claude-code)