### PR TITLE
subscription-summary-table: hide billing label for one-time price offers

### DIFF
--- a/components/subscription-summary-table/helpers/Schedule.ts
+++ b/components/subscription-summary-table/helpers/Schedule.ts
@@ -11,6 +11,9 @@ function formatBillingLabel(interval = 1, unit = "months") {
 }
 
 export function getOfferBillingLabel(offer: ElasticOffer): string {
+  const prices = offer?.data?.attributes?.price__limio
+  if (prices?.[0]?.type === "onetime") return ""
+
   const term = offer?.data?.attributes?.term__limio
   if (!term) return "N/A"
 


### PR DESCRIPTION
## Summary
- `getOfferBillingLabel` now returns `""` (empty) when `price__limio[0].type === "onetime"`, preventing misleading labels like "1-Year" being shown for one-time course purchases.

## Test plan
- [ ] Verify a subscription with a one-time price offer shows a blank billing plan cell in the summary table
- [ ] Verify a recurring subscription still shows the correct billing label (e.g. "1-Year", "1-Month")

🤖 Generated with [Claude Code](https://claude.com/claude-code)