### PR TITLE
cebroker-offer-cards: fix stale basket causing update endpoint on Buy Now

### DIFF
--- a/components/cebroker-offer-cards/index.js
+++ b/components/cebroker-offer-cards/index.js
@@ -140,7 +140,7 @@ export const CeBrokerOfferCards = () => {
 
     const { offers } = useCampaign();
     const basket = useBasket() || {};
-    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions, orderItems } = basket;
+    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions } = basket;
 
     const [selectedRole, setSelectedRole] = useState("");
     const [selectedState, setSelectedState] = useState("");
@@ -193,20 +193,18 @@ export const CeBrokerOfferCards = () => {
     const handleAdd = async (offer) => {
         try {
             const checkoutId = getCurrentBasketId && getCurrentBasketId();
-            // Only reuse the existing basket if it's still active (has items in the
-            // current session). A basket ID with no active orderItems means the
-            // previous checkout was completed/closed — start a fresh one instead.
-            const hasActiveBasket = checkoutId && orderItems && orderItems.length > 0;
-            if (hasActiveBasket && addOfferToBasket) {
-                await addOfferToBasket({ offer });
-            } else if (initiateCheckout) {
+            if (!checkoutId) {
                 await initiateCheckout({ order: { orderItems: [{ offer }] } });
-            }
-            if (pageOptions?.pushToCheckout && navigateToCheckout) {
-                await navigateToCheckout();
+            } else {
+                await addOfferToBasket({ offer });
             }
         } catch (e) {
-            console.warn("[cebroker-offer-cards] add to basket failed", e);
+            // addOfferToBasket failed — basket is likely completed/closed.
+            // Start a fresh checkout instead.
+            await initiateCheckout({ order: { orderItems: [{ offer }] } });
+        }
+        if (pageOptions?.pushToCheckout && navigateToCheckout) {
+            await navigateToCheckout();
         }
     };
 

--- a/components/cebroker-offer-cards/index.js
+++ b/components/cebroker-offer-cards/index.js
@@ -140,7 +140,7 @@ export const CeBrokerOfferCards = () => {
 
     const { offers } = useCampaign();
     const basket = useBasket() || {};
-    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions } = basket;
+    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions, orderItems } = basket;
 
     const [selectedRole, setSelectedRole] = useState("");
     const [selectedState, setSelectedState] = useState("");
@@ -193,10 +193,14 @@ export const CeBrokerOfferCards = () => {
     const handleAdd = async (offer) => {
         try {
             const checkoutId = getCurrentBasketId && getCurrentBasketId();
-            if (!checkoutId && initiateCheckout) {
-                await initiateCheckout({ order: { orderItems: [{ offer }] } });
-            } else if (addOfferToBasket) {
+            // Only reuse the existing basket if it's still active (has items in the
+            // current session). A basket ID with no active orderItems means the
+            // previous checkout was completed/closed — start a fresh one instead.
+            const hasActiveBasket = checkoutId && orderItems && orderItems.length > 0;
+            if (hasActiveBasket && addOfferToBasket) {
                 await addOfferToBasket({ offer });
+            } else if (initiateCheckout) {
+                await initiateCheckout({ order: { orderItems: [{ offer }] } });
             }
             if (pageOptions?.pushToCheckout && navigateToCheckout) {
                 await navigateToCheckout();


### PR DESCRIPTION
## Problem

`getCurrentBasketId()` returns the basket ID from any stored checkout — including completed ones. When a returning user (who already purchased) clicks Buy Now, `addOfferToBasket` hits the **update** endpoint (`POST /checkout/subscription`) against a closed basket and errors.

## Fix

Before deciding whether to add or initiate, check `orderItems.length`:

| Scenario | `checkoutId` | `orderItems` | Action |
|---|---|---|---|
| First visit / fresh session | null | 0 | `initiateCheckout` ✓ |
| Mid-session, adding 2nd course | set | > 0 | `addOfferToBasket` ✓ |
| Returning user (prior purchase) | set (stale) | 0 | `initiateCheckout` ✓ |

`orderItems` only reflects the **current session's active basket** — it's empty if the previous checkout was completed — so it's a reliable signal for whether the basket is genuinely in-progress.

## Related
- PR #66 applies the simpler "always fresh" fix to `offers-propelus`, which is a single-plan selector with no multi-item cart flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)