### PR TITLE
fix: use orderItems from useBasket to determine active basket state

### DIFF
--- a/components/cebroker-offer-cards/index.js
+++ b/components/cebroker-offer-cards/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useCampaign, useBasket } from "@limio/sdk";
-import { getCurrentBasketId } from "@limio/shop/src/shop/checkout/basket";
 import { useStaticProps } from "./componentStaticProps";
 import xss from "xss";
 import "./index.css";
@@ -140,7 +139,7 @@ export const CeBrokerOfferCards = () => {
 
     const { offers } = useCampaign();
     const basket = useBasket() || {};
-    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions } = basket;
+    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions, orderItems } = basket;
 
     const [selectedRole, setSelectedRole] = useState("");
     const [selectedState, setSelectedState] = useState("");
@@ -191,16 +190,12 @@ export const CeBrokerOfferCards = () => {
         (showGroupedOffers && offerGroups.length > 0) || showKeywordSearch;
 
     const handleAdd = async (offer) => {
-        try {
-            const checkoutId = getCurrentBasketId && getCurrentBasketId();
-            if (!checkoutId) {
-                await initiateCheckout({ order: { orderItems: [{ offer }] } });
-            } else {
-                await addOfferToBasket({ offer });
-            }
-        } catch (e) {
-            // addOfferToBasket failed — basket is likely completed/closed.
-            // Start a fresh checkout instead.
+        // orderItems is populated by the SDK for the current active basket only.
+        // It's empty when there's no basket or the previous checkout completed,
+        // so returning customers correctly get a fresh checkout.
+        if (orderItems?.length > 0) {
+            await addOfferToBasket({ offer });
+        } else {
             await initiateCheckout({ order: { orderItems: [{ offer }] } });
         }
         if (pageOptions?.pushToCheckout && navigateToCheckout) {

--- a/components/offers-propelus/components/AddToBasketButton.js
+++ b/components/offers-propelus/components/AddToBasketButton.js
@@ -1,22 +1,17 @@
 import React from "react"
 import { Button } from "@mui/material"
 import { useBasket } from "@limio/sdk"
-import { getCurrentBasketId } from "@limio/shop/src/shop/checkout/basket"
 
 export const AddToBasketButton = ({ offer, primaryColor }) => {
-    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions } = useBasket()
+    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions, orderItems } = useBasket()
 
     async function addSelectionToBasket() {
-        try {
-            const checkoutId = getCurrentBasketId()
-            if (!checkoutId) {
-                await initiateCheckout({ order: { orderItems: [{ offer }] } })
-            } else {
-                await addOfferToBasket({ offer })
-            }
-        } catch (e) {
-            // addOfferToBasket failed — basket is likely completed/closed.
-            // Start a fresh checkout instead.
+        // orderItems is populated by the SDK for the current active basket only.
+        // It's empty when there's no basket or the previous checkout completed,
+        // so returning customers correctly get a fresh checkout.
+        if (orderItems?.length > 0) {
+            await addOfferToBasket({ offer })
+        } else {
             await initiateCheckout({ order: { orderItems: [{ offer }] } })
         }
         if (pageOptions?.pushToCheckout) {


### PR DESCRIPTION
## Problem

Both components used `getCurrentBasketId()` (internal `@limio/shop` import) to decide whether to call `addOfferToBasket` or `initiateCheckout`. That ID persists in local storage after a checkout completes, so returning customers hit `addOfferToBasket` against a closed basket — causing the update endpoint to be called instead of initiating a fresh checkout.

## Fix

Replace with `orderItems` from `useBasket()`. The SDK populates `orderItems` only for the current active basket and clears it on completion, making it a reliable signal:

| Scenario | `orderItems` | Action |
|---|---|---|
| New customer / returning customer | `[]` | `initiateCheckout` ✓ |
| Mid-session, adding 2nd item | `[...]` | `addOfferToBasket` ✓ |

No internal imports, no try/catch guesswork.

## Files changed
- `components/cebroker-offer-cards/index.js`
- `components/offers-propelus/components/AddToBasketButton.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)