### PR TITLE
Port cancellation-flow components for Allwyn (stripe-demo)

### DIFF
--- a/components/cancel-survey-radio-button-create-basket/index.css
+++ b/components/cancel-survey-radio-button-create-basket/index.css
@@ -1,0 +1,171 @@
+@import '@fontsource/inter/400.css';
+@import '@fontsource/inter/500.css';
+@import '@fontsource/inter/600.css';
+@import '@fontsource/inter/700.css';
+@import '@fontsource/inter/800.css';
+
+:root {
+  --font-family: 'Inter', 'system-ui', 'Helvetica Neue', Arial, sans-serif;
+  --color-heading: #1A1A1A;
+  --color-body: #6B7280;
+  --color-text: #374151;
+  --color-divider: #E5E7EB;
+  /* Allwyn brand */
+  --color-primary: #6C2D91;
+}
+
+em {
+  font-style: italic;
+}
+
+.container {
+  padding: 3rem 1rem;
+  margin: 0 auto;
+  max-width: 900px;
+  font-family: var(--font-family);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.contentWrapper {
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.contentWrapperLeft {
+  flex-grow: 1;
+}
+
+.contentWrapperRight {
+  padding-left: 2rem;
+}
+
+/* h1 — matches offer-cards-material main heading */
+.heading {
+  margin: 0 0 1.25rem 0;
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--color-heading);
+  font-family: var(--font-family);
+  text-align: left;
+}
+
+/* subtitle — matches offer-cards-material subheading */
+.paragraph {
+  margin: 0 0 2.5rem 0;
+  font-size: 1.125rem;
+  font-weight: 300;
+  color: var(--color-body);
+  line-height: 1.6;
+  font-family: var(--font-family);
+  text-align: left;
+}
+
+.reasonList {
+  padding-bottom: 1.1rem;
+}
+
+/* h2 — section heading */
+.reasonListHeading {
+  margin: 0 0 1.25rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-heading);
+  font-family: var(--font-family);
+}
+
+.reasonListItem {
+  display: flex;
+  margin-bottom: 0.875rem;
+  align-items: center;
+}
+
+/* Allwyn-branded radio accent */
+.radioButton {
+  accent-color: var(--color-primary);
+}
+
+.reasonListItemLabel {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding-left: 0.75rem;
+  font-size: 0.9375rem;
+  font-weight: 400;
+  color: var(--color-text);
+  font-family: var(--font-family);
+  cursor: pointer;
+  line-height: 1.5;
+}
+
+.reasonImage {
+  display: block;
+  margin: 0;
+  padding: 0;
+  max-width: 350px;
+  border-radius: 8px;
+}
+
+.textboxLabel {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--color-heading);
+  font-family: var(--font-family);
+}
+
+.textbox {
+  display: block;
+  font-family: var(--font-family);
+  font-size: 0.9375rem;
+  color: var(--color-text);
+}
+
+.textbox:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(108, 45, 145, 0.2);
+}
+
+.divider {
+  margin: 1rem 0;
+  border: none;
+  border-top: 1px solid var(--color-divider);
+}
+
+.list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.listItem {
+  display: block;
+}
+
+@media (max-width: 640px) {
+  .heading {
+    font-size: 1.75rem;
+  }
+
+  .contentWrapper {
+    flex-wrap: wrap;
+  }
+
+  .contentWrapperRight {
+    display: none;
+  }
+
+  .list {
+    flex-direction: column;
+  }
+
+  .listItem {
+    width: 100%;
+  }
+}

--- a/components/cancel-survey-radio-button-create-basket/index.js
+++ b/components/cancel-survey-radio-button-create-basket/index.js
@@ -1,0 +1,151 @@
+import "./index.css"
+import React, { useState } from "react"
+import { Input, Label, Button } from "@limio/design-system"
+import { sanitiseHTML, useBasket } from "@limio/sdk"
+
+const CancelSurveyRadioButton = ({
+  title,
+  subtitle,
+  reasonsHeading,
+  reasons,
+  otherReasonLabel,
+  otherReasonValue,
+  otherReasonUrl,
+  showOtherReason,
+  captureOtherReasonText,
+  otherReasonCaptureTextLabel,
+  showImage,
+  imageUrl,
+  cancelButtonText,
+  keepSubscriptionButtonText,
+  keepSubscriptionUrl
+}) => {
+  const { initiateCheckout } = useBasket()
+
+  const [selectedReason, setSelectedReason] = useState(null)
+  const [otherReasonText, setOtherReasonText] = useState("")
+
+  const otherReason = {
+    label: otherReasonLabel,
+    value: otherReasonValue,
+    url: otherReasonUrl
+  }
+
+  const onCancel = async () => {
+    const subId = new URLSearchParams(window.location.search).get("subId")
+
+    const url = new URL(selectedReason.url, window.location.origin)
+    url.searchParams.set("subId", subId)
+    url.searchParams.set("reason", selectedReason.value)
+
+    if (selectedReason?.createBasket__limio_boolean) {
+      // Logic to create a new basket
+      const basket = await initiateCheckout({
+        order: {
+          order_type: "update_subscription",
+          forSubscription: {
+            id: subId
+          }
+        }
+      })
+
+      url.searchParams.set("basket", basket.order.checkoutId)
+    }
+
+    window.location.assign(url.toString())
+  }
+
+  const onKeepSubscription = () => {
+    window.location.assign(keepSubscriptionUrl)
+  }
+
+  return (
+    <main className={"container"}>
+      <div className={"contentWrapper"}>
+        <div className={"contentWrapperLeft"}>
+          <h1 className={"heading"}>{title}</h1>
+          <p
+            className={"paragraph"}
+            dangerouslySetInnerHTML={{ __html: sanitiseHTML(subtitle) }}
+          ></p>
+          <div className={"reasonList"}>
+            <h2
+              className={"reasonListHeading"}
+              dangerouslySetInnerHTML={{ __html: sanitiseHTML(reasonsHeading) }}
+            ></h2>
+            {reasons.map((r, i) => {
+              const id = `reason_${i}`
+
+              return (
+                <div key={r.value} className={"reasonListItem"}>
+                  <Input
+                    type="radio"
+                    id={id}
+                    value={r.value}
+                    checked={selectedReason === r}
+                    onChange={() => setSelectedReason(r)}
+                    className={"radioButton"}
+                  />
+                  <Label htmlFor={id} className={"reasonListItemLabel"}>
+                    {r.label}
+                  </Label>
+                </div>
+              )
+            })}
+            {showOtherReason && (
+              <div className={"reasonListItem"}>
+                <Input
+                  type="radio"
+                  id="reason_other"
+                  value={otherReason.value}
+                  checked={selectedReason?.value === otherReason.value}
+                  onChange={() => setSelectedReason(otherReason)}
+                  className={"radioButton"}
+                />
+                <Label htmlFor="reason_other" className={"reasonListItemLabel"}>
+                  {otherReason.label}
+                </Label>
+              </div>
+            )}
+            {captureOtherReasonText &&
+              selectedReason?.value === otherReason.value && (
+                <div>
+                  <Label htmlFor="other-reason-text" className={"textboxLabel"}>
+                    {otherReasonCaptureTextLabel}
+                  </Label>
+                  <Input
+                    type={"textarea"}
+                    id="other-reason-text"
+                    rows={5}
+                    className={"textbox"}
+                    value={otherReasonText}
+                    onChange={(e) => setOtherReasonText(e.target.value)}
+                  />
+                </div>
+              )}
+          </div>
+        </div>
+        {showImage && imageUrl && (
+          <div className={"contentWrapperRight"}>
+            <img src={imageUrl} role="presentation" className={"reasonImage"} />
+          </div>
+        )}
+      </div>
+      <hr className={"divider"} />
+      <div className={"list"}>
+        <div className={"listItem"}>
+          <Button onClick={onCancel} disabled={selectedReason == null}>
+            {cancelButtonText}
+          </Button>
+        </div>
+        <div className={"listItem"}>
+          <Button onClick={onKeepSubscription}>
+            {keepSubscriptionButtonText}
+          </Button>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+export default CancelSurveyRadioButton

--- a/components/cancel-survey-radio-button-create-basket/package.json
+++ b/components/cancel-survey-radio-button-create-basket/package.json
@@ -1,0 +1,171 @@
+{
+  "name": "@limio/component-cancel-survey-radio-button-create-basket",
+  "version": "1.0.0",
+  "description": "",
+  "main": "./index.js",
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@limio/design-system": "workspace:^"
+  },
+  "peerDependencies": {
+    "@limio/sdk": "workspace:^",
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "title",
+      "label": "Title",
+      "type": "string",
+      "default": "Before you go"
+    },
+    {
+      "id": "subtitle",
+      "label": "Subtitle",
+      "type": "string",
+      "default": "Please tell us why you want to cancel your subscription"
+    },
+    {
+      "id": "reasonsHeading",
+      "label": "Reasons heading",
+      "type": "richtext",
+      "default": "Why would you like to cancel your subscription?"
+    },
+    {
+      "id": "reasons",
+      "label": "Reasons",
+      "type": "list",
+      "fields": {
+        "label": {
+          "id": "label",
+          "label": "Label",
+          "type": "string"
+        },
+        "value": {
+          "id": "value",
+          "label": "Value",
+          "type": "string"
+        },
+        "url": {
+          "id": "url",
+          "label": "Url",
+          "type": "string"
+        },
+        "createBasket__limio_boolean": {
+          "id": "createBasket__limio_boolean",
+          "label": "Create update subscription basket",
+          "type": "boolean"
+        }
+      },
+      "default": [
+        {
+          "label": "expensive",
+          "value": "This subscription is too expensive",
+          "url": "/expensive",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "quantity",
+          "value": "I have too much",
+          "url": "/quantity",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "dislike",
+          "value": "I did not like the membership benefits",
+          "url": "/dislike",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "alternative",
+          "value": "I found an alternative",
+          "url": "/alternative",
+          "createBasket__limio_boolean": false
+        },
+        {
+          "label": "I'd rather not say",
+          "value": "Something else",
+          "url": "/help",
+          "createBasket__limio_boolean": false
+        }
+      ]
+    },
+    {
+      "id": "otherReasonLabel",
+      "label": "Other reason label",
+      "type": "string",
+      "default": "Other"
+    },
+    {
+      "id": "otherReasonValue",
+      "label": "Other reason value",
+      "type": "string",
+      "default": "Something else"
+    },
+    {
+      "id": "otherReasonUrl",
+      "label": "Other reason url",
+      "type": "string",
+      "default": "/other"
+    },
+    {
+      "id": "showOtherReason",
+      "label": "Show other reason",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "id": "captureOtherReasonText",
+      "label": "Capture other reason text",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "id": "otherReasonCaptureTextLabel",
+      "label": "Other reason capture text label",
+      "type": "string",
+      "default": "Add 'other' details below"
+    },
+    {
+      "id": "showImage",
+      "label": "Show image",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "id": "imageUrl",
+      "label": "Image Url",
+      "type": "string",
+      "default": "https://custom-images.strikinglycdn.com/res/hrscywv4p/image/upload/c_limit,fl_lossy,h_9000,w_1200,f_auto,q_auto/1156184/860406_495342.png"
+    },
+    {
+      "id": "cancelButtonText",
+      "label": "Cancel button text",
+      "type": "string",
+      "default": "Continue to cancel"
+    },
+    {
+      "id": "keepSubscriptionButtonText",
+      "label": "Keep subscription button text",
+      "type": "string",
+      "default": "Keep my subscription"
+    },
+    {
+      "id": "keepSubscriptionUrl",
+      "label": "Keep subscription url",
+      "type": "string",
+      "default": "https://limio.com"
+    }
+  ],
+  "type": "module",
+  "sideEffects": [
+    "*.css",
+    "*.scss",
+    "*.sass",
+    "*.less"
+  ]
+}

--- a/components/loss-benefit-cancel/componentStaticProps.js
+++ b/components/loss-benefit-cancel/componentStaticProps.js
@@ -1,0 +1,8 @@
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+import packageData from "./package.json"
+
+const defaultComponentProps = getPropsFromPackageJson(packageData)
+
+export function useStaticProps() {
+    return useComponentProps(defaultComponentProps)
+}

--- a/components/loss-benefit-cancel/index.css
+++ b/components/loss-benefit-cancel/index.css
@@ -1,0 +1,203 @@
+.lbc-container {
+    --lbc-primary: #6C2D91;
+    --lbc-text: #1a1f36;
+    --lbc-text-muted: #697386;
+    --lbc-border: #e3e8ee;
+    --lbc-bg: #f6f9fc;
+    --lbc-card: #ffffff;
+    --lbc-warning-bg: #fff7ed;
+    --lbc-warning-border: #fed7aa;
+    --lbc-feature-icon: #ef4444;
+
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    color: var(--lbc-text);
+    background: var(--lbc-bg);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 16px;
+    min-height: 100%;
+    -webkit-font-smoothing: antialiased;
+}
+
+.lbc-container *,
+.lbc-container *::before,
+.lbc-container *::after {
+    box-sizing: border-box;
+}
+
+.lbc-card {
+    background: var(--lbc-card);
+    border: 1px solid var(--lbc-border);
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.04);
+    max-width: 560px;
+    width: 100%;
+    padding: 40px 32px;
+    text-align: center;
+}
+
+.lbc-heading {
+    font-size: 24px;
+    font-weight: 700;
+    margin: 0 0 16px;
+    color: var(--lbc-text);
+}
+
+.lbc-plan-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--lbc-bg);
+    border: 1px solid var(--lbc-border);
+    border-radius: 8px;
+    padding: 8px 16px;
+    margin-bottom: 16px;
+}
+
+.lbc-plan-name {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--lbc-text);
+}
+
+.lbc-plan-price {
+    font-size: 14px;
+    color: var(--lbc-text-muted);
+}
+
+.lbc-plan-price p {
+    margin: 0;
+    display: inline;
+}
+
+.lbc-subheading {
+    font-size: 15px;
+    color: var(--lbc-text-muted);
+    margin: 0 0 24px;
+    line-height: 1.5;
+}
+
+.lbc-features {
+    background: var(--lbc-warning-bg);
+    border: 1px solid var(--lbc-warning-border);
+    border-radius: 10px;
+    padding: 20px 24px;
+    text-align: left;
+}
+
+.lbc-features-list ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.lbc-features-list li {
+    position: relative;
+    padding: 8px 0 8px 28px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--lbc-text);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.lbc-features-list li:last-child {
+    border-bottom: none;
+}
+
+.lbc-features-list li::before {
+    content: "✕";
+    position: absolute;
+    left: 0;
+    top: 8px;
+    color: var(--lbc-feature-icon);
+    font-weight: 700;
+    font-size: 13px;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Add-ons section */
+.lbc-addons-section {
+    margin-top: 24px;
+    text-align: center;
+}
+
+.lbc-addons-heading {
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0 0 8px;
+    color: var(--lbc-text);
+}
+
+.lbc-addons-description {
+    font-size: 14px;
+    color: var(--lbc-text-muted);
+    margin: 0 0 12px;
+    line-height: 1.5;
+}
+
+.lbc-addon-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    background: var(--lbc-bg);
+    border: 1px solid var(--lbc-border);
+    border-radius: 8px;
+    margin-bottom: 8px;
+    text-align: left;
+}
+
+.lbc-addon-item:last-child {
+    margin-bottom: 0;
+}
+
+.lbc-addon-name {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--lbc-text);
+    flex: 1;
+}
+
+.lbc-addon-price {
+    font-size: 14px;
+    color: var(--lbc-text-muted);
+}
+
+.lbc-addon-price p {
+    margin: 0;
+    display: inline;
+}
+
+.lbc-addon-tag {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--lbc-primary);
+    background: rgba(108, 45, 145, 0.08);
+    border-radius: 4px;
+    padding: 2px 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+@media (max-width: 600px) {
+    .lbc-container {
+        padding: 20px 12px;
+    }
+
+    .lbc-card {
+        padding: 28px 20px;
+    }
+
+    .lbc-heading {
+        font-size: 20px;
+    }
+
+    .lbc-features {
+        padding: 16px 18px;
+    }
+}

--- a/components/loss-benefit-cancel/index.js
+++ b/components/loss-benefit-cancel/index.js
@@ -1,0 +1,195 @@
+import React, { Suspense } from "react"
+import { useLimioContext, ErrorBoundary, sanitiseHTML } from "@limio/sdk"
+import { getCurrentOffer } from "@limio/shop/src/shop/helpers/checks"
+import { useLimioUserSubscription } from "@limio/internal-checkout-sdk"
+import { useAuthModeFetch } from "@limio/shop/src/components/helpers.tsx"
+import { useStaticProps } from "./componentStaticProps"
+import "./index.css"
+
+// Preview data shown in the Limio Page Builder when moustache templates are unresolved
+const PAGE_BUILDER_PREVIEW = {
+    planName: "Example Plan",
+    displayPrice: "<p><strong>$9.99/month</strong></p>",
+    featuresHtml: "<ul><li>Access to all plan features</li><li>Priority customer support</li><li>Monthly newsletter</li><li>Early access to new features</li></ul>",
+    addOns: [{ name: "Example Add-On", price: "<p>$4.99/month</p>" }],
+}
+
+function isMoustache(val) {
+    return typeof val === "string" && val.includes("{{")
+}
+
+function getActiveAddOns(addOns) {
+    if (!Array.isArray(addOns) || addOns.length === 0) return []
+
+    const now = new Date()
+    return addOns.filter(addOn => {
+        if (!["active", "pending", "pending-external"].includes(addOn.status)) return false
+        const end = addOn?.data?.end ? new Date(addOn.data.end) : null
+        const start = addOn?.data?.start ? new Date(addOn.data.start) : null
+        if (start && start > now) return false
+        if (end && end < now) return false
+        return true
+    })
+}
+
+function getAddOnAttributes(addOn) {
+    return addOn?.data?.offer?.data?.attributes || addOn?.data?.add_on?.data?.attributes || {}
+}
+
+function formatAddOnPrice(priceObj) {
+    if (!priceObj || typeof priceObj.amount !== "number") return ""
+    const currency = priceObj.currency || "USD"
+    return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(priceObj.amount)
+}
+
+// Renders the card UI — used by both live and page builder modes
+function LossBenefitCard({ resolvedPlanName, resolvedPrice, resolvedFeatures, activeAddOns, props }) {
+    const {
+        heading = "Here's what you'll lose",
+        subheading = "If you cancel your subscription, you'll no longer have access to these features:",
+        addOnsHeading = "You will also lose",
+        addOnDescription = "You'll also lose access to this add-on:",
+        primaryColor = "#6C2D91",
+        showPlanName = true,
+        showPrice = true,
+    } = props
+
+    return (
+        <section className="lbc-container" style={{ "--lbc-primary": primaryColor }}>
+            <div className="lbc-card">
+                {showPlanName && resolvedPlanName && (
+                    <div className="lbc-plan-badge">
+                        <span className="lbc-plan-name">{resolvedPlanName}</span>
+                        {showPrice && resolvedPrice && (
+                            <span
+                                className="lbc-plan-price"
+                                dangerouslySetInnerHTML={{ __html: sanitiseHTML(resolvedPrice) }}
+                            />
+                        )}
+                    </div>
+                )}
+
+                <h2 className="lbc-heading">{heading}</h2>
+                <p className="lbc-subheading">{subheading}</p>
+
+                <div className="lbc-features">
+                    <div
+                        className="lbc-features-list"
+                        dangerouslySetInnerHTML={{ __html: sanitiseHTML(resolvedFeatures) }}
+                    />
+                </div>
+
+                {activeAddOns.length > 0 && (
+                    <div className="lbc-addons-section">
+                        <h3 className="lbc-addons-heading">{addOnsHeading}</h3>
+                        <p className="lbc-addons-description">{addOnDescription}</p>
+                        {activeAddOns.map((addOn, i) => {
+                            const attrs = addOn?.data ? getAddOnAttributes(addOn) : {}
+                            const name = attrs.display_name__limio || addOn?.data?.add_on?.name || addOn?.data?.name || addOn?.name || ""
+                            const price = attrs.display_price__limio || formatAddOnPrice(addOn?.data?.price) || addOn?.price || ""
+
+                            return (
+                                <div key={i} className="lbc-addon-item">
+                                    <span className="lbc-addon-name">{name}</span>
+                                    {showPrice && price && (
+                                        <span
+                                            className="lbc-addon-price"
+                                            dangerouslySetInnerHTML={{ __html: sanitiseHTML(price) }}
+                                        />
+                                    )}
+                                    <span className="lbc-addon-tag">Add-on</span>
+                                </div>
+                            )
+                        })}
+                    </div>
+                )}
+            </div>
+        </section>
+    )
+}
+
+// Live page version — fetches subscription data via Suspense hook
+function LossBenefitCancelLive() {
+    const props = useStaticProps() || {}
+    const {
+        offerFeatures__limio_richtext = "",
+        fallbackFeatures__limio_richtext = "<ul><li>Access to all plan features</li><li>Customer support</li><li>Regular updates</li></ul>",
+        planName = "",
+        displayPrice = "",
+    } = props
+
+    const params = new URL(window.location).searchParams
+    const subIdParam = params.get("subId") || ""
+
+    const { userSubscription } = useLimioUserSubscription(subIdParam)
+
+    // Fetch add-ons via dedicated API endpoint (workaround: useLimioUserSubscription drops addOns)
+    const { data: addOnData } = useAuthModeFetch(
+        `/api/mma/subscriptions/${subIdParam}/related/subscription_add_on`,
+        { suspense: true }
+    )
+
+    // Get the current offer from the subscription
+    const offer = userSubscription ? getCurrentOffer(userSubscription) : null
+    const offerAttributes = offer?.data?.attributes || {}
+
+    // Subscription data is primary source, non-moustache props are overrides, fallback last
+    const resolvedPlanName = offerAttributes.display_name__limio || (!isMoustache(planName) && planName) || ""
+    const resolvedPrice = offerAttributes.display_price__limio || (!isMoustache(displayPrice) && displayPrice) || ""
+    const resolvedFeatures = offerAttributes.offer_features__limio || (!isMoustache(offerFeatures__limio_richtext) && offerFeatures__limio_richtext) || fallbackFeatures__limio_richtext
+
+    const activeAddOns = getActiveAddOns(addOnData?.items || [])
+
+    return (
+        <LossBenefitCard
+            resolvedPlanName={resolvedPlanName}
+            resolvedPrice={resolvedPrice}
+            resolvedFeatures={resolvedFeatures}
+            activeAddOns={activeAddOns}
+            props={props}
+        />
+    )
+}
+
+function LossBenefitCancel() {
+    const { isInPageBuilder } = useLimioContext() || {}
+    const props = useStaticProps() || {}
+
+    // Page builder: show preview data directly (no subscription fetch needed)
+    if (isInPageBuilder) {
+        return (
+            <LossBenefitCard
+                resolvedPlanName={PAGE_BUILDER_PREVIEW.planName}
+                resolvedPrice={PAGE_BUILDER_PREVIEW.displayPrice}
+                resolvedFeatures={PAGE_BUILDER_PREVIEW.featuresHtml}
+                activeAddOns={PAGE_BUILDER_PREVIEW.addOns}
+                props={props}
+            />
+        )
+    }
+
+    // Live page: fetch subscription data with Suspense
+    return (
+        <ErrorBoundary
+            fallback={
+                <div className="lbc-container">
+                    <p>Could not load subscription details.</p>
+                </div>
+            }
+        >
+            <Suspense
+                fallback={
+                    <div className="lbc-container">
+                        <div className="lbc-card">
+                            <p>Loading subscription details...</p>
+                        </div>
+                    </div>
+                }
+            >
+                <LossBenefitCancelLive />
+            </Suspense>
+        </ErrorBoundary>
+    )
+}
+
+export default LossBenefitCancel

--- a/components/loss-benefit-cancel/package.json
+++ b/components/loss-benefit-cancel/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@limio/loss-benefit-cancel",
+  "version": "1.0.0",
+  "description": "Shows users the benefits they will lose if they cancel their subscription",
+  "main": "./index.js",
+  "dependencies": {
+    "xss": "^1.0.15"
+  },
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "heading",
+      "label": "Heading",
+      "type": "string",
+      "default": "Here's what you'll lose"
+    },
+    {
+      "id": "subheading",
+      "label": "Card description text",
+      "type": "string",
+      "default": "If you cancel your subscription, you'll no longer have access to these features:"
+    },
+    {
+      "id": "primaryColor",
+      "label": "Primary color",
+      "type": "color",
+      "default": "#6C2D91"
+    },
+    {
+      "id": "offerFeatures__limio_richtext",
+      "label": "Offer features template",
+      "type": "richtext",
+      "default": "{{data.attributes.offer_features__limio}}"
+    },
+    {
+      "id": "planName",
+      "label": "Plan name template",
+      "type": "string",
+      "default": "{{data.attributes.display_name__limio}}"
+    },
+    {
+      "id": "displayPrice",
+      "label": "Display price template",
+      "type": "string",
+      "default": "{{data.attributes.display_price__limio}}"
+    },
+    {
+      "id": "fallbackFeatures__limio_richtext",
+      "label": "Fallback features (if offer has none)",
+      "type": "richtext",
+      "default": "<ul><li>Access to all plan features</li><li>Customer support</li><li>Regular updates</li></ul>"
+    },
+    {
+      "id": "addOnsHeading",
+      "label": "Add-ons section heading",
+      "type": "string",
+      "default": "You will also lose"
+    },
+    {
+      "id": "addOnDescription",
+      "label": "Add-on card description text",
+      "type": "string",
+      "default": "You'll also lose access to this add-on:"
+    },
+    {
+      "id": "showPlanName",
+      "label": "Show plan name",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "showPrice",
+      "label": "Show current price",
+      "type": "boolean",
+      "default": true
+    }
+  ]
+}


### PR DESCRIPTION
Ports two custom components from the `saas-dev` branch into `stripe`, rebranded to Allwyn purple (`#6C2D91`). Merging deploys them to the stripe-demo tenant.

## Components
- **cancel-survey-radio-button-create-basket** — cancel-reason radio survey. Each reason has a `url` (next step) and an optional "create update_subscription basket" toggle; primary action = continue-to-cancel, secondary = keep subscription. CSS accents (radio `accent-color`, textarea focus) set to Allwyn purple.
- **loss-benefit-cancel** — "here's what you'll lose" card. Reads the live subscription's offer features + active add-ons (page-builder preview when templates unresolved). `primaryColor` default changed `#002C5F` → `#6C2D91`; add-on tag tint updated to purple. Loss "✕" markers stay red.

## Notes
- Component **logic is unchanged** from saas-dev — only branding differs (per request: Allwyn-only, no theme selector).
- Intended use: new Allwyn pages `/allwyn/cancel-reason`, `/allwyn/cancel-save`, `/allwyn/cancel-benefits` (created separately via the catalog API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)