### PR TITLE
LI-10719: add eligibleRegion + areaServed to JSON-LD Schema offers

### DIFF
--- a/components/json-ld-schema/__tests__/buildJsonLd.test.js
+++ b/components/json-ld-schema/__tests__/buildJsonLd.test.js
@@ -5,6 +5,7 @@ import {
   stripHtml,
   extractFeatureList,
   mapBillingInterval,
+  mapEligibleRegion,
 } from "../buildJsonLd"
 
 // --- Helpers ---
@@ -366,5 +367,76 @@ describe("buildJsonLd", () => {
   test("handles empty/null offers gracefully", () => {
     expect(buildJsonLd([], [], defaultConfig).mainEntity.offers).toHaveLength(0)
     expect(buildJsonLd(null, null, defaultConfig).mainEntity.offers).toHaveLength(0)
+  })
+})
+
+// --- LI-10719: regional availability (eligibleRegion) ---
+
+describe("mapEligibleRegion", () => {
+  test("maps allowed_countries__limio to an array of ISO codes", () => {
+    expect(mapEligibleRegion({ allowed_countries__limio: ["BD", "BT", "ID"] })).toEqual([
+      "BD",
+      "BT",
+      "ID",
+    ])
+  })
+
+  test("returns null when allowed_countries__limio is empty or absent", () => {
+    expect(mapEligibleRegion({ allowed_countries__limio: [] })).toBeNull()
+    expect(mapEligibleRegion({})).toBeNull()
+    expect(mapEligibleRegion(null)).toBeNull()
+  })
+})
+
+describe("buildOfferSchema — eligibleRegion / areaServed", () => {
+  test("adds both eligibleRegion and areaServed from allowed_countries__limio", () => {
+    const offer = makeOffer({
+      attributes: { display_name__limio: "Annual", allowed_countries__limio: ["US", "CA"] },
+    })
+    const result = buildOfferSchema(offer, "Subscription")
+    expect(result.eligibleRegion).toEqual(["US", "CA"])
+    expect(result.areaServed).toEqual(["US", "CA"])
+  })
+
+  test("omits both eligibleRegion and areaServed when the offer has no allowed countries", () => {
+    const result = buildOfferSchema(makeOffer(), "Subscription")
+    expect(result.eligibleRegion).toBeUndefined()
+    expect(result.areaServed).toBeUndefined()
+  })
+})
+
+describe("buildJsonLd — eligibleRegion", () => {
+  function zoneOffer(zone, countries, value, currency) {
+    return makeOffer({
+      path: `/offers2/${zone}`,
+      price: [{ value, currencyCode: currency, repeat_interval: 1, repeat_interval_type: "years" }],
+      attributes: { display_name__limio: "Annual", allowed_countries__limio: countries },
+    })
+  }
+
+  const offers = [
+    zoneOffer("zone-us", ["US"], 299, "USD"),
+    zoneOffer("zone-gb", ["GB"], 229, "GBP"),
+    zoneOffer("zone-eu", ["FR", "DE"], 249, "EUR"),
+  ]
+
+  function byRegion(result, code) {
+    return result.mainEntity.offers.find((o) => (o.eligibleRegion || []).includes(code))
+  }
+
+  test("each zone's offer carries its own eligibleRegion alongside its price/currency", () => {
+    const result = buildJsonLd(offers, [], defaultConfig)
+    expect(result.mainEntity.offers).toHaveLength(3)
+    expect(byRegion(result, "US").priceCurrency).toBe("USD")
+    expect(byRegion(result, "GB").priceCurrency).toBe("GBP")
+    expect(byRegion(result, "FR").eligibleRegion).toEqual(["FR", "DE"])
+    expect(byRegion(result, "FR").priceCurrency).toBe("EUR")
+  })
+
+  test("offers with no allowed_countries__limio simply omit region fields (treated as global)", () => {
+    const global = zoneOffer("zone-global", [], 199, "USD")
+    const result = buildJsonLd([global], [], defaultConfig)
+    expect(result.mainEntity.offers[0].eligibleRegion).toBeUndefined()
+    expect(result.mainEntity.offers[0].areaServed).toBeUndefined()
   })
 })

--- a/components/json-ld-schema/buildJsonLd.js
+++ b/components/json-ld-schema/buildJsonLd.js
@@ -30,6 +30,18 @@ export function mapBillingInterval(type) {
 }
 
 /**
+ * Map an offer's allowed_countries__limio to schema.org eligibleRegion.
+ * @param {object} attrs - offer.data.attributes
+ * @returns {string[]|null} ISO 3166-1 alpha-2 codes, or null when empty/absent (offer is global)
+ */
+export function mapEligibleRegion(attrs) {
+  const countries = attrs?.allowed_countries__limio
+  if (!Array.isArray(countries) || countries.length === 0) return null
+  const cleaned = countries.filter((code) => typeof code === "string" && code.trim() !== "")
+  return cleaned.length > 0 ? cleaned : null
+}
+
+/**
  * Extract individual features from offer_features__limio HTML.
  * Parses each <li> into a ListItem for search engine indexing.
  */
@@ -134,6 +146,16 @@ export function buildOfferSchema(offer, category, purchaseConfig, offerDetailsFi
         },
       }
     }
+  }
+
+  // Regional availability — which countries this offer applies to. Emitted as both
+  // eligibleRegion (precise: the region the offer is valid for) and areaServed (the
+  // far more widely-recognised general property) so more consumers pick it up.
+  // Omitted entirely when the offer has no allowed_countries__limio (available everywhere).
+  const eligibleRegion = mapEligibleRegion(attrs)
+  if (eligibleRegion) {
+    schema.eligibleRegion = eligibleRegion
+    schema.areaServed = eligibleRegion
   }
 
   // Purchase / checkout link with UTM tracking


### PR DESCRIPTION
## Why

Large customers (e.g. The Economist) put **all price-zone offers on a single page** and filter them on the front end by the visitor's country (`?lmo_co=US`, geo, CDN journeys). Because the JSON-LD Schema component bakes its output at **publish time**, it emitted every zone's offer with no signal of which applied where — presenting the zones as interchangeable to AI agents.

## What changed

Scoped to regional availability.

- **`mapEligibleRegion(attrs)`** (new, exported) — maps `allowed_countries__limio` to an array of ISO 3166-1 alpha-2 codes; returns `null` when empty/absent.
- **`buildOfferSchema`** sets both **`eligibleRegion`** and **`areaServed`** from that list. `eligibleRegion` is the precise, offer/pricing-specific property ("the region the offer is valid for"); `areaServed` is the general, far more widely-recognised one ("the area where the offered item is provided"). Both are valid Text properties of `Offer` per schema.org, so emitting both maximises the chance a consumer picks up the signal at no semantic cost. When the offer has no allowed countries, both are **omitted** (treated as available everywhere).

Codes are emitted verbatim — no normalisation. The stored data is already clean uppercase alpha-2, and codes like `XK` (Kosovo, a user-assigned code) must be preserved, so validating against the official ISO list would be wrong.

No new props; `index.js` / `package.json` unchanged. The `WebPage → mainEntity → offers[]` shape is unchanged — each offer just gains `eligibleRegion` + `areaServed` when it has allowed countries.

## Tests

`components/json-ld-schema/__tests__/buildJsonLd.test.js`: **43 baseline (untouched) + 6 new = 49 passing**. New coverage: `mapEligibleRegion` (maps codes; empty/absent → null), both region fields present/omitted on the offer node, each zone carries its own region alongside its price/currency, and a global offer omits both fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
