### PR TITLE
Cafeyn B2B demo: cafeyn-* components + design language

### DIFF
--- a/CAFEYN-DEMO-SCRIPT.md
+++ b/CAFEYN-DEMO-SCRIPT.md
@@ -1,0 +1,98 @@
+# Cafeyn B2B Demo — Script
+
+Demo for Juliette & Alexandre (call in English, **everything on screen in German** —
+Alexandre is building the German pricing model; Germany is the wedge, §6.4).
+All URLs on `saas-dev-shop.prod.limio.com`. Test card `4242 4242 4242 4242`,
+any future expiry/CVC.
+
+> Setup before the call: one browser tab on `/ca-pricing`, one on the Limio admin
+> (Orders + [process events](https://saas-dev.prod.limio.com/objects/events/limio)),
+> one on Salesforce with the demo opportunity. Have the generated payment link
+> ready (see `checkout_link.py`) as backup.
+
+---
+
+## Act 1 — Self-serve: "just let me pay ~€500 and go" (~4 min)
+
+**Pain**: B2B today is a quote-request form; small companies just want to buy.
+**Benchmark**: The Economist — count the clicks out loud. Landing → paid is 3 steps.
+
+1. Open **`/ca-pricing`** — unmistakably Cafeyn (Oil-brown on cream, Newsreader
+   serif, covers marquee). All German.
+2. Toggle **Monatlich ↔ Jährlich** (−17 % chip), step the **Anzahl Lizenzen** to
+   5 — Team card recalculates live: *600 € pro Jahr für 5 Nutzer*. Right in
+   their stated €500–2,000 sweet spot. **Click 1: „Mit Team starten“.**
+3. **`/ca-checkout`** — the checkout-customizability proof (their literal
+   evaluation question, §6.1):
+   - B2B fields: **Firmenname, USt-IdNr., Branche** (dropdown) — all custom
+     config, not code.
+   - Quantity editable in the cart; **Add-ons** (Internationale Presse +3 €,
+     Audio & Podcasts +2 €) one click away; upsell nudge to Business.
+   - Enter promo **`CAFEYN20`** — *20 % Rabatt im ersten Jahr* („launch promo
+     for the DACH rollout").
+   - **Click 2: fill details; Click 3: „Kaufen“.**
+4. **`/ca-confirm`** — *Willkommen bei Cafeyn for Business* — plan, Lizenzen,
+   Add-ons, next charge, invite-your-team next steps.
+5. Flip to Limio admin: the order + outbound events (webhooks). Narrate
+   **Chargebee coexistence** (§6.2): "these same events feed Salesforce — Limio
+   industrialises your B2B *on top of* the billing you already run."
+
+## Act 2 — Self-service account: phase 2, already working (~3 min)
+
+**Pain**: invoices are hand-made in Salesforce; expansion is manual.
+
+1. **`/ca-account`** — subscription overview. **Add 3 seats**
+   (`/ca-direct-update` — proration shown before confirming).
+2. **Upgrade Team → Business** (`/ca-direct-update-sub`) — the upgrade path you
+   wired into the offers; monthly → annual term switch lives here too.
+3. Add the **Audio & Podcasts** add-on post-purchase.
+4. **`/ca-invoices`** — *Rechnungen / Zahlungsverlauf*, downloadable. "Generated
+   automatically at checkout — nobody hand-writes these anymore" (§6.3).
+5. Start cancellation from the account: the **save offer** intercepts
+   (*20 % Rabatt für 12 Monate*, `/ca-cancel-save`) → accept → retained. Decline
+   path shows the German exit survey.
+
+## Act 3 — Sales-assisted: 100 clicks → 3 (~3 min)
+
+**Pain**: Salesforce is central (~9 reps); quotes have no bridge to billing.
+
+1. In Salesforce, open the demo opportunity → **Generate checkout link** with
+   the negotiated offer (*Business — 25 Lizenzen, Sonderkonditionen, 10 €/Nutzer/Monat*).
+   (Backup: run `checkout_link.py` and paste the link.)
+2. Open the link as the buyer: **`/ca-quote-checkout`** — fields pre-filled and
+   locked from the SF account (Firmenname, Unternehmensgröße, Branche, Bereits
+   Cafeyn-Nutzer?), negotiated price, nothing to negotiate on-page. Pay.
+3. Back in Salesforce: order lands on the account. "Rep sends a link instead of
+   raising an invoice — that's the 100-clicks-to-3 story."
+
+## Act 4 — B2C → B2B conversion (the revenue story, ~2 min)
+
+**Pain**: thousands of businesses buy B2C subs today.
+
+1. Show the **Cafeyn Premium** (12,99 €) B2C subscription on a demo account.
+2. From its account view, the upgrade path offers **Cafeyn for Business Team** —
+   switch, seats added, done. "Every B2C business user is a self-serve B2B lead."
+
+## Closers
+
+- **Germany first, then everywhere**: cloning this catalog for FR/UK is
+  configuration (currencies, labels, pages), not a project.
+- **Agentic teaser** (optional 2 min, §6.6): the Limio agent with
+  `build_checkout_link` qualifies and routes to checkout — Chargebee can't.
+- Deliberately not shown: trials, deep seat-management (their phase 2 — the
+  seat change in My Account proves the rails exist).
+
+---
+
+## Runbook notes
+
+- Offer catalog: `cafeyn-b2b` label (Team/Business × monthly/annual),
+  `cafeyn-b2c` (Premium), `cafeyn-sales` (25-seat negotiated + CSE),
+  `cafeyn-save` (retention discount), add-ons `cafeyn-addons-monthly/annual`,
+  promo `CAFEYN20`.
+- Pages: flat `ca-*` tags; all anonymous auth (required for the Salesforce
+  OBO link flow).
+- After each order/upgrade/cancel in rehearsal, check
+  [process events](https://saas-dev.prod.limio.com/objects/events/limio) —
+  a UI-green order can still fail downstream.
+- Components ship from this repo via the `saas-dev` branch (PR merge = deploy).

--- a/component-playground/.storybook/preview-head.html
+++ b/component-playground/.storybook/preview-head.html
@@ -1,0 +1,7 @@
+<!-- Brand fonts used by client-branded components (Cafeyn: Newsreader + Source Sans 3) -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400..600&family=Source+Sans+3:wght@400;600&display=swap"
+  rel="stylesheet"
+/>

--- a/component-playground/packages/limio/internal-checkout-sdk/index.js
+++ b/component-playground/packages/limio/internal-checkout-sdk/index.js
@@ -152,3 +152,53 @@ export function useLimioUserPaymentMethods() {
     mutate: () => {}
   }
 }
+
+// Mirrors the shop's completed-checkout session hook: same selector interface
+// as useCheckout, but for the order that was just placed (order-confirmation
+// components read customer, items and references from here).
+export function useCompleteCheckoutSession() {
+  const order = {
+    order_reference: "ORD-2026-000123",
+    sub_reference: "SUB-2026-000456",
+    currency: "EUR",
+    customerDetails: {
+      firstName: "Julia",
+      lastName: "Schneider",
+      email: "julia.schneider@example.de",
+      companyName: "Schneider & Partner GmbH"
+    },
+    orderItems: [
+      {
+        id: "item-1",
+        quantity: 5,
+        offer: {
+          data: {
+            attributes: {
+              display_name__limio: "Team",
+              display_price__limio: "<p>10 € pro Nutzer/Monat</p>"
+            }
+          }
+        },
+        crossSell: [
+          {
+            offer: {
+              data: {
+                attributes: { display_name__limio: "Audio & Podcasts" }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+
+  function useCheckoutSelector(callback) {
+    return callback({ order, completed: true })
+  }
+
+  return { useCheckoutSelector }
+}
+
+export function useLimioUserSubscriptionPaymentMethods() {
+  return useLimioUserPaymentMethods()
+}

--- a/component-playground/src/stories/cafeyn-covers-band.stories.jsx
+++ b/component-playground/src/stories/cafeyn-covers-band.stories.jsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { LimioProvider, ComponentContext } from "@limio/sdk"
+import CafeynCoversBand from "../../../components/cafeyn-covers-band"
+
+export default {
+    title: "Cafeyn/Covers Band",
+    component: CafeynCoversBand,
+    parameters: { layout: "fullscreen" },
+    tags: ["autodocs"],
+    decorators: [
+        (Story, context) => (
+            <LimioProvider>
+                <ComponentContext.Provider value={context.args}>
+                    <Story />
+                </ComponentContext.Provider>
+            </LimioProvider>
+        ),
+    ],
+}
+
+export const Default = { args: {} }
+
+export const SlowScroll = {
+    args: { scrollSeconds: 60 },
+}

--- a/component-playground/src/stories/cafeyn-hero.stories.jsx
+++ b/component-playground/src/stories/cafeyn-hero.stories.jsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { LimioProvider, ComponentContext } from "@limio/sdk"
+import CafeynHero from "../../../components/cafeyn-hero"
+
+export default {
+    title: "Cafeyn/Hero",
+    component: CafeynHero,
+    parameters: { layout: "fullscreen" },
+    tags: ["autodocs"],
+    decorators: [
+        (Story, context) => (
+            <LimioProvider>
+                <ComponentContext.Provider value={context.args}>
+                    <Story />
+                </ComponentContext.Provider>
+            </LimioProvider>
+        ),
+    ],
+}
+
+export const Default = { args: {} }
+
+export const WithoutCovers = {
+    args: { showCovers: false },
+}
+
+export const EnglishFallback = {
+    args: {
+        kicker: "Cafeyn for Business",
+        heading: "The entire press for your team",
+        subheading: "<p>2,500+ newspapers and magazines for every employee — one subscription, every title.</p>",
+        primaryCta: "See plans",
+        secondaryCta: "Contact sales",
+        finePrint: "1–10 licenses self-serve · invoice & card payment",
+    },
+}

--- a/component-playground/src/stories/cafeyn-offers.stories.jsx
+++ b/component-playground/src/stories/cafeyn-offers.stories.jsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { LimioProvider, ComponentContext } from "@limio/sdk"
+import CafeynOffers from "../../../components/cafeyn-offers"
+
+const eur = (value, interval) => [{
+    name: "charge_1",
+    label: "Charge 1",
+    value: String(value),
+    currencyCode: "EUR",
+    type: "recurring",
+    trigger: "order_date",
+    repeat_interval: 1,
+    repeat_interval_type: interval,
+}]
+
+const cafeynOffer = (id, name, group, value, interval, extra = {}) => ({
+    id,
+    path: `/offers2/Cafeyn ${name} ${group === "yearly" ? "Annual" : "Monthly"} EUR`,
+    data: {
+        attributes: {
+            display_name__limio: name,
+            group__limio: group,
+            allow_multibuy__limio: true,
+            best_value__limio: false,
+            price__limio: eur(value, interval),
+            ...extra,
+        },
+        price: eur(value, interval),
+        products: [],
+        attachments: [],
+    },
+})
+
+const TEAM_FEATURES = "<ul><li>Über 2.500 Zeitungen &amp; Magazine</li><li>Bis zu 10 Lizenzen</li><li>Offline lesen auf allen Geräten</li><li>Smart Reader Artikelansicht</li></ul>"
+const BIZ_FEATURES = "<ul><li><strong>Alles aus Team +</strong></li><li>Audio-Artikel &amp; Podcasts</li><li>Lese-Analysen für Ihr Team</li><li>Priorisierter Support</li></ul>"
+
+const cafeynOffers = [
+    cafeynOffer("team-m", "Team", "monthly", 12, "months", {
+        display_price__limio: "<p><strong>12&nbsp;€</strong> pro Nutzer/Monat</p>",
+        detailed_display_price__limio: "<p>Monatliche Abrechnung · jederzeit kündbar</p>",
+        offer_features__limio: TEAM_FEATURES,
+        cta_text__limio: "Mit Team starten",
+    }),
+    cafeynOffer("biz-m", "Business", "monthly", 18, "months", {
+        display_price__limio: "<p><strong>18&nbsp;€</strong> pro Nutzer/Monat</p>",
+        detailed_display_price__limio: "<p>Monatliche Abrechnung · jederzeit kündbar</p>",
+        offer_features__limio: BIZ_FEATURES,
+        cta_text__limio: "Business wählen",
+        best_value__limio: true,
+    }),
+    cafeynOffer("team-a", "Team", "yearly", 120, "years", {
+        display_price__limio: "<p><strong>10&nbsp;€</strong> pro Nutzer/Monat</p>",
+        detailed_display_price__limio: "<p>120&nbsp;€ pro Nutzer/Jahr · jährliche Abrechnung</p>",
+        offer_features__limio: TEAM_FEATURES,
+        cta_text__limio: "Mit Team starten",
+    }),
+    cafeynOffer("biz-a", "Business", "yearly", 180, "years", {
+        display_price__limio: "<p><strong>15&nbsp;€</strong> pro Nutzer/Monat</p>",
+        detailed_display_price__limio: "<p>180&nbsp;€ pro Nutzer/Jahr · jährliche Abrechnung</p>",
+        offer_features__limio: BIZ_FEATURES,
+        cta_text__limio: "Business wählen",
+        best_value__limio: true,
+    }),
+]
+
+const shopValue = {
+    shop: {
+        campaign: { name: "Cafeyn B2B", path: "/pages/ca-pricing", attributes: { pushToCheckout: false } },
+        offers: cafeynOffers,
+        addOns: [],
+        basketItems: [],
+    },
+}
+
+export default {
+    title: "Cafeyn/Offers",
+    component: CafeynOffers,
+    parameters: { layout: "fullscreen" },
+    tags: ["autodocs"],
+    decorators: [
+        (Story, context) => (
+            <LimioProvider value={shopValue}>
+                <ComponentContext.Provider value={context.args}>
+                    <Story />
+                </ComponentContext.Provider>
+            </LimioProvider>
+        ),
+    ],
+}
+
+export const Default = { args: {} }
+
+export const WithoutEnterpriseCard = {
+    args: { showEnterpriseCard: false },
+}
+
+export const OneLicense = {
+    args: { defaultQuantity: 1 },
+}

--- a/component-playground/src/stories/cafeyn-order-confirmation.stories.jsx
+++ b/component-playground/src/stories/cafeyn-order-confirmation.stories.jsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { LimioProvider, ComponentContext } from "@limio/sdk"
+import CafeynOrderConfirmation from "../../../components/cafeyn-order-confirmation"
+
+export default {
+    title: "Cafeyn/Order Confirmation",
+    component: CafeynOrderConfirmation,
+    parameters: { layout: "fullscreen" },
+    tags: ["autodocs"],
+    decorators: [
+        (Story, context) => (
+            <LimioProvider>
+                <ComponentContext.Provider value={context.args}>
+                    <Story />
+                </ComponentContext.Provider>
+            </LimioProvider>
+        ),
+    ],
+}
+
+// Order data comes from the playground's @limio/internal-checkout-sdk mock
+// (useCompleteCheckoutSession): Julia Schneider, Team ×5, Audio add-on.
+export const Default = { args: {} }
+
+export const WithoutSteps = {
+    args: { steps: [] },
+}

--- a/components/cafeyn-covers-band/componentStaticProps.js
+++ b/components/cafeyn-covers-band/componentStaticProps.js
@@ -1,0 +1,8 @@
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+import packageData from "./package.json"
+
+const defaultComponentProps = getPropsFromPackageJson(packageData)
+
+export function useStaticProps() {
+    return useComponentProps(defaultComponentProps)
+}

--- a/components/cafeyn-covers-band/index.css
+++ b/components/cafeyn-covers-band/index.css
@@ -1,0 +1,122 @@
+.cafeyn-covers {
+  --cafeyn-oil: #211712;
+  --cafeyn-cream: #FFFDF9;
+  --cafeyn-surface: #F2ECE2;
+  --cafeyn-bone: #DED0B9;
+  --cafeyn-caramel: #885F46;
+  --cafeyn-latte: #D2BD9F;
+  --cafeyn-muted: #5C4F45;
+  --cafeyn-white: #FFFFFF;
+  --cafeyn-line: #E7DFD2;
+  --cafeyn-font-serif: "Newsreader", Georgia, serif;
+  --cafeyn-font-sans: "Source Sans 3", "Source Sans Pro", -apple-system, sans-serif;
+  font-family: var(--cafeyn-font-sans);
+  color: var(--cafeyn-oil);
+  background: var(--cafeyn-surface);
+  padding: 3.5rem 0;
+  overflow: hidden;
+}
+
+.cafeyn-covers *,
+.cafeyn-covers *::before,
+.cafeyn-covers *::after {
+  box-sizing: border-box;
+}
+
+.cafeyn-covers__heading {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 1.75rem;
+  font-weight: 500;
+  text-align: center;
+  margin: 0 0 2rem;
+}
+
+.cafeyn-covers__viewport {
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+
+.cafeyn-covers__track {
+  display: flex;
+  gap: 1.25rem;
+  width: max-content;
+  animation: cafeyn-covers-scroll var(--duration, 35s) linear infinite;
+}
+
+.cafeyn-covers__viewport:hover .cafeyn-covers__track {
+  animation-play-state: paused;
+}
+
+@keyframes cafeyn-covers-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cafeyn-covers__track {
+    animation: none;
+  }
+}
+
+.cafeyn-covers__cover {
+  width: 8rem;
+  aspect-ratio: 2 / 3;
+  flex-shrink: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(33, 23, 18, 0.15);
+  background: var(--cafeyn-white);
+}
+
+.cafeyn-covers__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cafeyn-covers__placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0.7rem;
+  gap: 0.5rem;
+}
+
+.cafeyn-covers__masthead {
+  font-family: var(--cafeyn-font-serif);
+  font-weight: 600;
+  font-size: 0.85rem;
+  line-height: 1.15;
+  word-break: break-word;
+}
+
+.cafeyn-covers__lines {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.cafeyn-covers__lines i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: currentColor;
+  opacity: 0.35;
+}
+
+.cafeyn-covers__lines i:nth-child(2) { width: 70%; }
+.cafeyn-covers__lines i:nth-child(3) { width: 45%; }
+
+@media (max-width: 767px) {
+  .cafeyn-covers {
+    padding: 2.5rem 0;
+  }
+
+  .cafeyn-covers__cover {
+    width: 6.5rem;
+  }
+}

--- a/components/cafeyn-covers-band/index.js
+++ b/components/cafeyn-covers-band/index.js
@@ -1,0 +1,62 @@
+import React from "react"
+import { ErrorBoundary } from "@limio/sdk"
+import { useStaticProps } from "./componentStaticProps"
+import "./index.css"
+
+const COVER_TONES = [
+    { bg: "#211712", fg: "#FFFDF9" },
+    { bg: "#885F46", fg: "#FFFDF9" },
+    { bg: "#DED0B9", fg: "#211712" },
+    { bg: "#B33A3A", fg: "#FFFDF9" },
+    { bg: "#2E4A3E", fg: "#FFFDF9" },
+    { bg: "#3B3A5A", fg: "#FFFDF9" },
+]
+
+const Cover = ({ item, index }) => {
+    const tone = COVER_TONES[index % COVER_TONES.length]
+    return (
+        <div className="cafeyn-covers__cover">
+            {item.image ? (
+                <img src={item.image} alt={item.label || ""} loading="lazy" />
+            ) : (
+                <div className="cafeyn-covers__placeholder" style={{ background: tone.bg, color: tone.fg }}>
+                    <span className="cafeyn-covers__masthead">{item.label}</span>
+                    <span className="cafeyn-covers__lines" aria-hidden="true"><i /><i /><i /></span>
+                </div>
+            )}
+        </div>
+    )
+}
+
+const CafeynCoversBand = () => {
+    const props = useStaticProps() || {}
+    const { heading = "", titles = [], scrollSeconds = 35, componentId = "cafeyn-covers-band" } = props
+
+    if (!titles?.length) return null
+    // Duplicate the strip so the marquee loops seamlessly.
+    const strip = [...titles, ...titles]
+
+    return (
+        <section id={componentId} className="cafeyn-covers">
+            {heading?.trim() && <h2 className="cafeyn-covers__heading">{heading}</h2>}
+            <div className="cafeyn-covers__viewport">
+                <div className="cafeyn-covers__track" style={{ "--duration": `${Number(scrollSeconds) || 35}s` }}>
+                    {strip.map((item, i) => (
+                        <Cover key={`${item.id || item.label}-${i}`} item={item} index={i % titles.length} />
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}
+
+CafeynCoversBand.Skeleton = () => <div className="cafeyn-covers" style={{ minHeight: "14rem" }} />
+CafeynCoversBand.Error = () => null
+
+const Wrapped = () => (
+    <ErrorBoundary fallback={<CafeynCoversBand.Error />}>
+        <CafeynCoversBand />
+    </ErrorBoundary>
+)
+
+export default Wrapped

--- a/components/cafeyn-covers-band/package.json
+++ b/components/cafeyn-covers-band/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@limio/cafeyn-covers-band",
+  "version": "1.0.0",
+  "description": "Scrolling marquee strip of publication covers on a Cafeyn surface band — leads with German titles. Styled placeholders when no cover images are set.",
+  "main": "./index.js",
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    { "id": "heading", "label": "Band heading", "type": "string", "default": "Über 2.500 Titel — von 500+ Verlagen" },
+    {
+      "id": "titles",
+      "label": "Publication covers (image optional)",
+      "type": "list",
+      "fields": {
+        "id": { "id": "id", "label": "ID", "type": "string" },
+        "label": { "id": "label", "label": "Title", "type": "string" },
+        "image": { "id": "image", "label": "Cover image URL", "type": "string", "format": "uri", "purpose": "image" }
+      },
+      "default": [
+        { "id": "spiegel", "label": "DER SPIEGEL", "image": "" },
+        { "id": "stern", "label": "stern", "image": "" },
+        { "id": "focus", "label": "FOCUS", "image": "" },
+        { "id": "elffreunde", "label": "11FREUNDE", "image": "" },
+        { "id": "brigitte", "label": "BRIGITTE", "image": "" },
+        { "id": "geo", "label": "GEO", "image": "" },
+        { "id": "capital", "label": "CAPITAL", "image": "" },
+        { "id": "lemonde", "label": "Le Monde", "image": "" },
+        { "id": "independent", "label": "The Independent", "image": "" },
+        { "id": "autobild", "label": "AUTO BILD", "image": "" }
+      ]
+    },
+    { "id": "scrollSeconds", "label": "Marquee loop duration (seconds)", "type": "number", "default": 35 },
+    { "id": "componentId", "label": "Component Id", "type": "string", "default": "cafeyn-covers-band" }
+  ]
+}

--- a/components/cafeyn-hero/componentStaticProps.js
+++ b/components/cafeyn-hero/componentStaticProps.js
@@ -1,0 +1,8 @@
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+import packageData from "./package.json"
+
+const defaultComponentProps = getPropsFromPackageJson(packageData)
+
+export function useStaticProps() {
+    return useComponentProps(defaultComponentProps)
+}

--- a/components/cafeyn-hero/index.css
+++ b/components/cafeyn-hero/index.css
@@ -1,0 +1,237 @@
+.cafeyn-hero {
+  --cafeyn-oil: #211712;
+  --cafeyn-cream: #FFFDF9;
+  --cafeyn-surface: #F2ECE2;
+  --cafeyn-bone: #DED0B9;
+  --cafeyn-caramel: #885F46;
+  --cafeyn-latte: #D2BD9F;
+  --cafeyn-muted: #5C4F45;
+  --cafeyn-white: #FFFFFF;
+  --cafeyn-line: #E7DFD2;
+  --cafeyn-font-serif: "Newsreader", Georgia, serif;
+  --cafeyn-font-sans: "Source Sans 3", "Source Sans Pro", -apple-system, sans-serif;
+  --cafeyn-radius-btn: 8px;
+  --cafeyn-radius-card: 16px;
+  --cafeyn-radius-pill: 9999px;
+  --cafeyn-shadow-rest: 0 1px 3px rgba(33, 23, 18, 0.06);
+  --cafeyn-shadow-lift: 0 12px 32px rgba(33, 23, 18, 0.12);
+  font-family: var(--cafeyn-font-sans);
+  color: var(--cafeyn-oil);
+  background: var(--cafeyn-cream);
+}
+
+.cafeyn-hero *,
+.cafeyn-hero *::before,
+.cafeyn-hero *::after {
+  box-sizing: border-box;
+}
+
+.cafeyn-hero__inner {
+  width: 90%;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 4.5rem 0 4rem;
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+}
+
+.cafeyn-hero__copy {
+  flex: 1 1 55%;
+  min-width: 0;
+}
+
+.cafeyn-hero__kicker {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cafeyn-caramel);
+  margin-bottom: 1rem;
+}
+
+.cafeyn-hero__heading {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 3.5rem;
+  line-height: 1.1;
+  font-weight: 500;
+  margin: 0 0 1.25rem;
+  color: var(--cafeyn-oil);
+}
+
+.cafeyn-hero__sub {
+  font-size: 1.1875rem;
+  line-height: 1.6;
+  color: var(--cafeyn-muted);
+  max-width: 34rem;
+}
+
+.cafeyn-hero__sub p {
+  margin: 0 0 0.75rem;
+}
+
+.cafeyn-hero__ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.75rem;
+}
+
+.cafeyn-hero__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--cafeyn-radius-btn);
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.cafeyn-hero__btn--primary {
+  background: var(--cafeyn-oil);
+  color: var(--cafeyn-white);
+}
+
+.cafeyn-hero__btn--primary:hover {
+  background: #3a2b22;
+}
+
+.cafeyn-hero__btn--secondary {
+  background: var(--cafeyn-white);
+  color: var(--cafeyn-oil);
+  border: 1px solid var(--cafeyn-oil);
+}
+
+.cafeyn-hero__btn--secondary:hover {
+  background: var(--cafeyn-surface);
+}
+
+.cafeyn-hero__fine {
+  margin: 1.25rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--cafeyn-muted);
+}
+
+/* Cover collage */
+.cafeyn-hero__collage {
+  flex: 1 1 45%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0;
+  padding: 1rem 0;
+}
+
+.cafeyn-hero__cover {
+  width: 8.5rem;
+  aspect-ratio: 2 / 3;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(33, 23, 18, 0.15);
+  transform: rotate(var(--tilt, 0deg));
+  margin-left: -1.5rem;
+  background: var(--cafeyn-surface);
+  transition: transform 0.2s ease;
+}
+
+.cafeyn-hero__cover:first-child {
+  margin-left: 0;
+}
+
+.cafeyn-hero__cover:hover {
+  transform: rotate(var(--tilt, 0deg)) translateY(-6px);
+}
+
+.cafeyn-hero__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cafeyn-hero__cover-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem;
+  gap: 0.6rem;
+}
+
+.cafeyn-hero__cover-masthead {
+  font-family: var(--cafeyn-font-serif);
+  font-weight: 600;
+  font-size: 0.9rem;
+  line-height: 1.15;
+  letter-spacing: 0.02em;
+  word-break: break-word;
+}
+
+.cafeyn-hero__cover-lines {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cafeyn-hero__cover-lines i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: currentColor;
+  opacity: 0.35;
+}
+
+.cafeyn-hero__cover-lines i:nth-child(2) {
+  width: 75%;
+}
+
+.cafeyn-hero__cover-lines i:nth-child(3) {
+  width: 50%;
+}
+
+/* Skeleton */
+.cafeyn-hero__skl {
+  background: var(--cafeyn-surface);
+  border-radius: 6px;
+  margin-bottom: 0.75rem;
+  animation: cafeyn-hero-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes cafeyn-hero-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+@media (max-width: 991px) {
+  .cafeyn-hero__heading {
+    font-size: 2.75rem;
+  }
+
+  .cafeyn-hero__cover {
+    width: 7rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .cafeyn-hero__inner {
+    flex-direction: column;
+    padding: 2.5rem 0;
+    gap: 2rem;
+  }
+
+  .cafeyn-hero__heading {
+    font-size: 2.25rem;
+  }
+
+  .cafeyn-hero__collage {
+    width: 100%;
+  }
+
+  .cafeyn-hero__cover {
+    width: 6rem;
+    margin-left: -1.25rem;
+  }
+}

--- a/components/cafeyn-hero/index.js
+++ b/components/cafeyn-hero/index.js
@@ -1,0 +1,114 @@
+import React from "react"
+import { ErrorBoundary } from "@limio/sdk"
+import xss from "xss"
+import { useStaticProps } from "./componentStaticProps"
+import "./index.css"
+
+const sanitize = (str) => xss(str || "")
+
+// Styled placeholder palette for covers without an image — warm editorial
+// tones so the collage carries color the way real covers would.
+const COVER_TONES = [
+    { bg: "#211712", fg: "#FFFDF9" },
+    { bg: "#885F46", fg: "#FFFDF9" },
+    { bg: "#DED0B9", fg: "#211712" },
+    { bg: "#B33A3A", fg: "#FFFDF9" },
+    { bg: "#2E4A3E", fg: "#FFFDF9" },
+]
+
+const Cover = ({ cover, index }) => {
+    const tone = COVER_TONES[index % COVER_TONES.length]
+    return (
+        <div className="cafeyn-hero__cover" style={{ "--tilt": `${(index % 2 ? 1 : -1) * (2 + index)}deg` }}>
+            {cover.image ? (
+                <img src={cover.image} alt={cover.label || ""} loading="lazy" />
+            ) : (
+                <div className="cafeyn-hero__cover-placeholder" style={{ background: tone.bg, color: tone.fg }}>
+                    <span className="cafeyn-hero__cover-masthead">{cover.label}</span>
+                    <span className="cafeyn-hero__cover-lines" aria-hidden="true">
+                        <i /><i /><i />
+                    </span>
+                </div>
+            )}
+        </div>
+    )
+}
+
+const CafeynHero = () => {
+    const props = useStaticProps() || {}
+    const {
+        kicker = "",
+        heading = "",
+        subheading = "",
+        primaryCta = "",
+        primaryCtaHref = "#plaene",
+        secondaryCta = "",
+        secondaryCtaHref = "#",
+        finePrint = "",
+        showCovers = true,
+        covers = [],
+        componentId = "cafeyn-hero",
+    } = props
+
+    return (
+        <section id={componentId} className="cafeyn-hero">
+            <div className="cafeyn-hero__inner">
+                <div className="cafeyn-hero__copy">
+                    {kicker?.trim() && <div className="cafeyn-hero__kicker">{kicker}</div>}
+                    {heading?.trim() && <h1 className="cafeyn-hero__heading">{heading}</h1>}
+                    {subheading?.trim() && (
+                        <div className="cafeyn-hero__sub" dangerouslySetInnerHTML={{ __html: sanitize(subheading) }} />
+                    )}
+                    <div className="cafeyn-hero__ctas">
+                        {primaryCta?.trim() && (
+                            <a className="cafeyn-hero__btn cafeyn-hero__btn--primary" href={primaryCtaHref || "#"}>
+                                {primaryCta}
+                            </a>
+                        )}
+                        {secondaryCta?.trim() && (
+                            <a className="cafeyn-hero__btn cafeyn-hero__btn--secondary" href={secondaryCtaHref || "#"}>
+                                {secondaryCta}
+                            </a>
+                        )}
+                    </div>
+                    {finePrint?.trim() && <p className="cafeyn-hero__fine">{finePrint}</p>}
+                </div>
+                {showCovers && covers?.length > 0 && (
+                    <div className="cafeyn-hero__collage" aria-hidden="true">
+                        {covers.slice(0, 5).map((cover, i) => (
+                            <Cover key={cover.id || i} cover={cover} index={i} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </section>
+    )
+}
+
+CafeynHero.Skeleton = () => (
+    <div className="cafeyn-hero cafeyn-hero--skeleton">
+        <div className="cafeyn-hero__inner">
+            <div className="cafeyn-hero__copy">
+                <div className="cafeyn-hero__skl" style={{ width: "30%", height: 14 }} />
+                <div className="cafeyn-hero__skl" style={{ width: "80%", height: 44 }} />
+                <div className="cafeyn-hero__skl" style={{ width: "60%", height: 18 }} />
+            </div>
+        </div>
+    </div>
+)
+
+CafeynHero.Error = () => (
+    <div className="cafeyn-hero">
+        <div className="cafeyn-hero__inner">
+            <p>Dieser Inhalt kann gerade nicht geladen werden. Bitte laden Sie die Seite neu.</p>
+        </div>
+    </div>
+)
+
+const Wrapped = () => (
+    <ErrorBoundary fallback={<CafeynHero.Error />}>
+        <CafeynHero />
+    </ErrorBoundary>
+)
+
+export default Wrapped

--- a/components/cafeyn-hero/package.json
+++ b/components/cafeyn-hero/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@limio/cafeyn-hero",
+  "version": "1.0.0",
+  "description": "Cafeyn for Business pricing-page hero — Newsreader headline, subcopy, CTAs, magazine-cover collage. German copy by default.",
+  "main": "./index.js",
+  "dependencies": {
+    "xss": "^1.0.8"
+  },
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    { "id": "kicker", "label": "Kicker", "type": "string", "default": "Cafeyn for Business" },
+    { "id": "heading", "label": "Heading", "type": "string", "default": "Die ganze Presse für Ihr Team" },
+    {
+      "id": "subheading",
+      "label": "Subheading (rich text)",
+      "type": "richtext",
+      "default": "<p>Über 2.500 Zeitungen und Magazine für jede Mitarbeiterin und jeden Mitarbeiter — ein Abo, alle Titel, jederzeit kündbar.</p>"
+    },
+    { "id": "primaryCta", "label": "Primary CTA", "type": "string", "default": "Pläne ansehen" },
+    { "id": "primaryCtaHref", "label": "Primary CTA link", "type": "string", "default": "#plaene" },
+    { "id": "secondaryCta", "label": "Secondary CTA", "type": "string", "default": "Vertrieb kontaktieren" },
+    { "id": "secondaryCtaHref", "label": "Secondary CTA link", "type": "string", "default": "mailto:business@cafeyn.co" },
+    { "id": "finePrint", "label": "Fine print under CTAs", "type": "string", "default": "1–10 Lizenzen im Self-Service · Rechnung & Kartenzahlung · DSGVO-konform" },
+    { "id": "showCovers", "label": "Show cover collage", "type": "boolean", "default": true },
+    {
+      "id": "covers",
+      "label": "Magazine covers (image optional — styled placeholder used when empty)",
+      "type": "list",
+      "fields": {
+        "id": { "id": "id", "label": "ID", "type": "string" },
+        "label": { "id": "label", "label": "Title", "type": "string" },
+        "image": { "id": "image", "label": "Cover image URL", "type": "string", "format": "uri", "purpose": "image" }
+      },
+      "default": [
+        { "id": "spiegel", "label": "DER SPIEGEL", "image": "" },
+        { "id": "stern", "label": "stern", "image": "" },
+        { "id": "focus", "label": "FOCUS", "image": "" },
+        { "id": "elffreunde", "label": "11FREUNDE", "image": "" },
+        { "id": "lemonde", "label": "Le Monde", "image": "" }
+      ]
+    },
+    { "id": "componentId", "label": "Component Id", "type": "string", "default": "cafeyn-hero" }
+  ]
+}

--- a/components/cafeyn-offers/componentStaticProps.js
+++ b/components/cafeyn-offers/componentStaticProps.js
@@ -1,0 +1,8 @@
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+import packageData from "./package.json"
+
+const defaultComponentProps = getPropsFromPackageJson(packageData)
+
+export function useStaticProps() {
+    return useComponentProps(defaultComponentProps)
+}

--- a/components/cafeyn-offers/index.css
+++ b/components/cafeyn-offers/index.css
@@ -1,0 +1,343 @@
+.cafeyn-offers {
+  --cafeyn-oil: #211712;
+  --cafeyn-cream: #FFFDF9;
+  --cafeyn-surface: #F2ECE2;
+  --cafeyn-bone: #DED0B9;
+  --cafeyn-caramel: #885F46;
+  --cafeyn-latte: #D2BD9F;
+  --cafeyn-muted: #5C4F45;
+  --cafeyn-white: #FFFFFF;
+  --cafeyn-line: #E7DFD2;
+  --cafeyn-font-serif: "Newsreader", Georgia, serif;
+  --cafeyn-font-sans: "Source Sans 3", "Source Sans Pro", -apple-system, sans-serif;
+  --cafeyn-radius-btn: 8px;
+  --cafeyn-radius-card: 16px;
+  --cafeyn-radius-pill: 9999px;
+  --cafeyn-shadow-rest: 0 1px 3px rgba(33, 23, 18, 0.06);
+  --cafeyn-shadow-lift: 0 12px 32px rgba(33, 23, 18, 0.12);
+  font-family: var(--cafeyn-font-sans);
+  color: var(--cafeyn-oil);
+  background: var(--cafeyn-cream);
+}
+
+.cafeyn-offers *,
+.cafeyn-offers *::before,
+.cafeyn-offers *::after {
+  box-sizing: border-box;
+}
+
+.cafeyn-offers__inner {
+  width: 90%;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 4.5rem 0;
+}
+
+.cafeyn-offers__headline {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 2.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+  text-align: center;
+  margin: 0 0 0.75rem;
+}
+
+.cafeyn-offers__subheadline {
+  text-align: center;
+  color: var(--cafeyn-muted);
+  font-size: 1.0625rem;
+  margin: 0 0 2rem;
+}
+
+/* Toolbar: term toggle + seat stepper */
+.cafeyn-offers__toolbar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.cafeyn-offers__toggle {
+  display: inline-flex;
+  background: var(--cafeyn-surface);
+  border: 1px solid var(--cafeyn-line);
+  border-radius: var(--cafeyn-radius-pill);
+  padding: 0.25rem;
+}
+
+.cafeyn-offers__toggle-btn {
+  border: 0;
+  background: transparent;
+  padding: 0.5rem 1.25rem;
+  border-radius: var(--cafeyn-radius-pill);
+  font-family: var(--cafeyn-font-sans);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--cafeyn-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.cafeyn-offers__toggle-btn--active {
+  background: var(--cafeyn-oil);
+  color: var(--cafeyn-white);
+}
+
+.cafeyn-offers__savings {
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--cafeyn-bone);
+  color: var(--cafeyn-oil);
+  border-radius: var(--cafeyn-radius-pill);
+  padding: 0.1rem 0.5rem;
+}
+
+.cafeyn-offers__stepper-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cafeyn-offers__stepper-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--cafeyn-muted);
+}
+
+.cafeyn-offers__stepper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--cafeyn-surface);
+  border: 1px solid var(--cafeyn-line);
+  border-radius: var(--cafeyn-radius-pill);
+  padding: 0.25rem;
+}
+
+.cafeyn-offers__stepper button {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 0;
+  background: var(--cafeyn-white);
+  color: var(--cafeyn-oil);
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: var(--cafeyn-shadow-rest);
+}
+
+.cafeyn-offers__stepper button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.cafeyn-offers__stepper-count {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 1.25rem;
+  font-weight: 500;
+  min-width: 2rem;
+  text-align: center;
+}
+
+/* Cards */
+.cafeyn-offers__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.cafeyn-offers__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--cafeyn-white);
+  border: 1px solid var(--cafeyn-line);
+  border-radius: var(--cafeyn-radius-card);
+  padding: 2rem 1.75rem 1.75rem;
+  box-shadow: var(--cafeyn-shadow-rest);
+}
+
+.cafeyn-offers__card--featured {
+  border: 2px solid var(--cafeyn-oil);
+  box-shadow: var(--cafeyn-shadow-lift);
+}
+
+.cafeyn-offers__card--enterprise {
+  background: var(--cafeyn-surface);
+  border-style: dashed;
+}
+
+.cafeyn-offers__badge {
+  position: absolute;
+  top: -0.8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--cafeyn-bone);
+  color: var(--cafeyn-oil);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  border-radius: var(--cafeyn-radius-pill);
+  padding: 0.2rem 0.9rem;
+  white-space: nowrap;
+}
+
+.cafeyn-offers__plan {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin: 0 0 0.75rem;
+}
+
+.cafeyn-offers__price {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 1.375rem;
+  line-height: 1.3;
+}
+
+.cafeyn-offers__price p,
+.cafeyn-offers__price-detail p {
+  margin: 0;
+}
+
+.cafeyn-offers__price-detail {
+  color: var(--cafeyn-muted);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.cafeyn-offers__total {
+  margin-top: 0.75rem;
+  background: rgba(222, 208, 185, 0.35);
+  border-radius: var(--cafeyn-radius-btn);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.cafeyn-offers__features {
+  margin: 1.25rem 0 1.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--cafeyn-muted);
+  flex: 1 1 auto;
+}
+
+.cafeyn-offers__features ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cafeyn-offers__features li {
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.cafeyn-offers__features li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.2rem;
+  width: 1.125rem;
+  height: 1.125rem;
+  border-radius: 50%;
+  background: rgba(222, 208, 185, 0.5);
+}
+
+.cafeyn-offers__features li::after {
+  content: "";
+  position: absolute;
+  left: 0.28rem;
+  top: 0.48rem;
+  width: 0.5rem;
+  height: 0.28rem;
+  border-left: 2px solid var(--cafeyn-caramel);
+  border-bottom: 2px solid var(--cafeyn-caramel);
+  transform: rotate(-45deg);
+}
+
+.cafeyn-offers__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0.75rem 1.5rem;
+  border: 0;
+  border-radius: var(--cafeyn-radius-btn);
+  background: var(--cafeyn-oil);
+  color: var(--cafeyn-white);
+  font-family: var(--cafeyn-font-sans);
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.cafeyn-offers__cta:hover {
+  background: #3a2b22;
+}
+
+.cafeyn-offers__cta:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.cafeyn-offers__cta--secondary {
+  background: var(--cafeyn-white);
+  color: var(--cafeyn-oil);
+  border: 1px solid var(--cafeyn-oil);
+}
+
+.cafeyn-offers__cta--secondary:hover {
+  background: var(--cafeyn-cream);
+}
+
+.cafeyn-offers__hint {
+  text-align: center;
+  color: var(--cafeyn-muted);
+  font-size: 0.8125rem;
+  margin: 1.5rem 0 0;
+}
+
+.cafeyn-offers__card--skeleton {
+  min-height: 22rem;
+  background: var(--cafeyn-surface);
+  border: 0;
+  animation: cafeyn-offers-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes cafeyn-offers-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+@media (max-width: 767px) {
+  .cafeyn-offers__inner {
+    padding: 2.5rem 0;
+  }
+
+  .cafeyn-offers__headline {
+    font-size: 2rem;
+  }
+
+  .cafeyn-offers__toolbar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .cafeyn-offers__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/components/cafeyn-offers/index.js
+++ b/components/cafeyn-offers/index.js
@@ -1,0 +1,266 @@
+import React, { useMemo, useState } from "react"
+import { ErrorBoundary, useBasket, useCampaign, useLimioContext } from "@limio/sdk"
+import { groupBy, prop } from "ramda"
+import xss from "xss"
+import { useStaticProps } from "./componentStaticProps"
+import "./index.css"
+
+const sanitize = (str) => xss(str || "")
+
+const fillTemplate = (tpl, vars) => String(tpl || "").replace(/\{(\w+)\}/g, (_, k) => (vars[k] ?? ""))
+
+// German currency formatting: "600 €" / "12,99 €"
+const formatEur = (value, currency = "EUR") => {
+    const num = Number(value)
+    if (!Number.isFinite(num)) return ""
+    return new Intl.NumberFormat("de-DE", {
+        style: "currency",
+        currency,
+        minimumFractionDigits: num % 1 === 0 ? 0 : 2,
+        maximumFractionDigits: 2,
+    }).format(num)
+}
+
+const getUnitPrice = (offer) => {
+    const charge = offer?.data?.attributes?.price__limio?.[0] || offer?.data?.price?.[0]
+    if (!charge) return null
+    const value = Number(charge.value)
+    return Number.isFinite(value) ? { value, currency: charge.currencyCode || "EUR" } : null
+}
+
+const groupOffersByTerm = groupBy(prop("group__limio"))
+
+const OfferCard = ({ offer, quantity, props, onBuy, busy }) => {
+    const attributes = offer?.data?.attributes || {}
+    const {
+        display_name__limio: name,
+        display_price__limio: displayPrice,
+        detailed_display_price__limio: detailedPrice,
+        offer_features__limio: features,
+        cta_text__limio: cta,
+        best_value__limio: bestValue,
+        allow_multibuy__limio: multibuy,
+        group__limio: group,
+    } = attributes
+
+    const unit = getUnitPrice(offer)
+    const isYearly = group === "yearly"
+    const total = unit && multibuy ? unit.value * quantity : unit?.value
+    const totalTemplate = isYearly ? props.totalTemplateYearly : props.totalTemplateMonthly
+
+    return (
+        <article className={`cafeyn-offers__card${bestValue ? " cafeyn-offers__card--featured" : ""}`}>
+            {bestValue && <div className="cafeyn-offers__badge">{props.bestValueLabel}</div>}
+            <h3 className="cafeyn-offers__plan">{name}</h3>
+            {displayPrice && (
+                <div className="cafeyn-offers__price" dangerouslySetInnerHTML={{ __html: sanitize(displayPrice) }} />
+            )}
+            {detailedPrice && (
+                <div className="cafeyn-offers__price-detail" dangerouslySetInnerHTML={{ __html: sanitize(detailedPrice) }} />
+            )}
+            {unit && multibuy && (
+                <div className="cafeyn-offers__total">
+                    {fillTemplate(totalTemplate, { total: formatEur(total, unit.currency), count: quantity })}
+                </div>
+            )}
+            {features && (
+                <div className="cafeyn-offers__features" dangerouslySetInnerHTML={{ __html: sanitize(features) }} />
+            )}
+            <button
+                type="button"
+                className="cafeyn-offers__cta"
+                disabled={busy}
+                onClick={() => onBuy(offer)}
+            >
+                {cta || "Jetzt starten"}
+            </button>
+        </article>
+    )
+}
+
+const CafeynOffers = () => {
+    const { offers } = useCampaign() || {}
+    const basket = useBasket() || {}
+    const { isInPageBuilder } = useLimioContext() || {}
+    const props = useStaticProps() || {}
+    const {
+        headline = "",
+        subheadline = "",
+        groupLabels = [],
+        annualSavingsLabel = "",
+        quantityLabel = "",
+        quantityHint = "",
+        minQuantity = 1,
+        maxQuantity = 10,
+        defaultQuantity = 5,
+        showEnterpriseCard = true,
+        enterpriseName = "",
+        enterprisePrice = "",
+        enterpriseFeatures = "",
+        enterpriseCta = "",
+        enterpriseCtaHref = "#",
+        componentId = "plaene",
+    } = props
+
+    const { addOfferToBasket, initiateCheckout, navigateToCheckout, pageOptions, orderItems, basketLoading } = basket
+
+    const min = Number(minQuantity) || 1
+    const max = Number(maxQuantity) || 10
+    const clamp = (n) => Math.min(max, Math.max(min, n))
+    const [quantity, setQuantity] = useState(() => clamp(Number(defaultQuantity) || 1))
+
+    const grouped = useMemo(() => {
+        if (!Array.isArray(offers)) return {}
+        return groupOffersByTerm(
+            offers.map((offer) => ({
+                ...offer,
+                group__limio: offer?.data?.attributes?.group__limio || "default",
+            }))
+        )
+    }, [offers])
+
+    const validLabels = useMemo(() => {
+        const groups = Object.keys(grouped)
+        const configured = (groupLabels || []).filter((item) => groups.includes(item.id))
+        if (configured.length > 0) return configured
+        return groups.map((g) => ({ id: g, label: g }))
+    }, [groupLabels, grouped])
+
+    const [selectedGroup, setSelectedGroup] = useState("")
+    const activeGroup = selectedGroup || validLabels[validLabels.length - 1]?.id || ""
+    const displayedOffers = grouped[activeGroup] || []
+
+    const handleBuy = async (offer) => {
+        try {
+            // orderItems is only populated for the current active basket, so a
+            // completed checkout correctly starts fresh (see cebroker-offer-cards).
+            const multibuy = offer?.data?.attributes?.allow_multibuy__limio
+            const qty = multibuy ? quantity : 1
+            if (orderItems?.length > 0) {
+                await addOfferToBasket({ offer, quantity: qty })
+            } else {
+                await initiateCheckout({ order: { orderItems: [{ offer, quantity: qty }] } })
+            }
+            if (pageOptions?.pushToCheckout !== false && navigateToCheckout) {
+                await navigateToCheckout()
+            }
+        } catch (error) {
+            console.error("Cafeyn offers: add to basket failed", error)
+        }
+    }
+
+    if (!offers?.length && !isInPageBuilder) return null
+
+    return (
+        <section id={componentId} className="cafeyn-offers">
+            <div className="cafeyn-offers__inner">
+                {headline?.trim() && <h2 className="cafeyn-offers__headline">{headline}</h2>}
+                {subheadline?.trim() && <p className="cafeyn-offers__subheadline">{subheadline}</p>}
+
+                <div className="cafeyn-offers__toolbar">
+                    {validLabels.length > 1 && (
+                        <div className="cafeyn-offers__toggle" role="tablist" aria-label={headline}>
+                            {validLabels.map((item) => (
+                                <button
+                                    key={item.id}
+                                    type="button"
+                                    role="tab"
+                                    aria-selected={activeGroup === item.id}
+                                    className={`cafeyn-offers__toggle-btn${activeGroup === item.id ? " cafeyn-offers__toggle-btn--active" : ""}`}
+                                    onClick={() => setSelectedGroup(item.id)}
+                                >
+                                    {item.label}
+                                    {item.id === "yearly" && annualSavingsLabel?.trim() && (
+                                        <span className="cafeyn-offers__savings">{annualSavingsLabel}</span>
+                                    )}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                    <div className="cafeyn-offers__stepper-wrap">
+                        {quantityLabel?.trim() && <span className="cafeyn-offers__stepper-label">{quantityLabel}</span>}
+                        <div className="cafeyn-offers__stepper">
+                            <button
+                                type="button"
+                                aria-label="Weniger Lizenzen"
+                                disabled={quantity <= min}
+                                onClick={() => setQuantity((q) => clamp(q - 1))}
+                            >
+                                −
+                            </button>
+                            <span className="cafeyn-offers__stepper-count">{quantity}</span>
+                            <button
+                                type="button"
+                                aria-label="Mehr Lizenzen"
+                                disabled={quantity >= max}
+                                onClick={() => setQuantity((q) => clamp(q + 1))}
+                            >
+                                +
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="cafeyn-offers__grid">
+                    {displayedOffers.map((offer, i) => (
+                        <OfferCard
+                            key={offer?.id || i}
+                            offer={offer}
+                            quantity={quantity}
+                            props={props}
+                            onBuy={handleBuy}
+                            busy={!!basketLoading}
+                        />
+                    ))}
+                    {showEnterpriseCard && (
+                        <article className="cafeyn-offers__card cafeyn-offers__card--enterprise">
+                            <h3 className="cafeyn-offers__plan">{enterpriseName}</h3>
+                            <div className="cafeyn-offers__price">
+                                <p><strong>{enterprisePrice}</strong></p>
+                            </div>
+                            {enterpriseFeatures && (
+                                <div
+                                    className="cafeyn-offers__features"
+                                    dangerouslySetInnerHTML={{ __html: sanitize(enterpriseFeatures) }}
+                                />
+                            )}
+                            <a className="cafeyn-offers__cta cafeyn-offers__cta--secondary" href={enterpriseCtaHref || "#"}>
+                                {enterpriseCta}
+                            </a>
+                        </article>
+                    )}
+                </div>
+
+                {quantityHint?.trim() && <p className="cafeyn-offers__hint">{quantityHint}</p>}
+            </div>
+        </section>
+    )
+}
+
+CafeynOffers.Skeleton = () => (
+    <div className="cafeyn-offers">
+        <div className="cafeyn-offers__inner">
+            <div className="cafeyn-offers__grid">
+                {[0, 1, 2].map((i) => (
+                    <div key={i} className="cafeyn-offers__card cafeyn-offers__card--skeleton" />
+                ))}
+            </div>
+        </div>
+    </div>
+)
+
+CafeynOffers.Error = () => (
+    <div className="cafeyn-offers">
+        <div className="cafeyn-offers__inner">
+            <p>Die Pläne können gerade nicht geladen werden. Bitte laden Sie die Seite neu.</p>
+        </div>
+    </div>
+)
+
+const Wrapped = () => (
+    <ErrorBoundary fallback={<CafeynOffers.Error />}>
+        <CafeynOffers />
+    </ErrorBoundary>
+)
+
+export default Wrapped

--- a/components/cafeyn-offers/package.json
+++ b/components/cafeyn-offers/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@limio/cafeyn-offers",
+  "version": "1.0.0",
+  "description": "Cafeyn B2B pricing cards — monthly/annual toggle, per-seat quantity stepper with live totals, best-value badge, static Enterprise contact card. German copy by default.",
+  "main": "./index.js",
+  "dependencies": {
+    "ramda": "^0.28.0",
+    "xss": "^1.0.8"
+  },
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    { "id": "headline", "label": "Section headline", "type": "string", "default": "Wählen Sie Ihren Plan" },
+    { "id": "subheadline", "label": "Section subheadline", "type": "string", "default": "Pro Nutzer, transparent, jederzeit anpassbar. 1–10 Lizenzen im Self-Service." },
+    {
+      "id": "groupLabels",
+      "label": "Term toggle labels (id = group__limio)",
+      "type": "list",
+      "fields": {
+        "id": { "id": "id", "label": "Group ID", "type": "string" },
+        "label": { "id": "label", "label": "Display label", "type": "string" }
+      },
+      "default": [
+        { "id": "monthly", "label": "Monatlich" },
+        { "id": "yearly", "label": "Jährlich" }
+      ]
+    },
+    { "id": "annualSavingsLabel", "label": "Savings chip on annual toggle", "type": "string", "default": "−17 %" },
+    { "id": "quantityLabel", "label": "Quantity stepper label", "type": "string", "default": "Anzahl Lizenzen" },
+    { "id": "quantityHint", "label": "Quantity hint", "type": "string", "default": "Mehr als 10 Lizenzen? Sprechen Sie mit unserem Vertrieb." },
+    { "id": "minQuantity", "label": "Min licenses", "type": "number", "default": 1 },
+    { "id": "maxQuantity", "label": "Max licenses", "type": "number", "default": 10 },
+    { "id": "defaultQuantity", "label": "Default licenses", "type": "number", "default": 5 },
+    { "id": "bestValueLabel", "label": "Best-value badge text", "type": "string", "default": "Beliebteste Wahl" },
+    { "id": "perSeatSuffixMonthly", "label": "Per-seat suffix (monthly)", "type": "string", "default": "pro Nutzer/Monat" },
+    { "id": "perSeatSuffixYearly", "label": "Per-seat suffix (annual)", "type": "string", "default": "pro Nutzer/Monat" },
+    { "id": "totalTemplateMonthly", "label": "Total line (monthly) — {total}, {count}", "type": "string", "default": "{total} pro Monat für {count} Nutzer" },
+    { "id": "totalTemplateYearly", "label": "Total line (annual) — {total}, {count}", "type": "string", "default": "{total} pro Jahr für {count} Nutzer" },
+    { "id": "showEnterpriseCard", "label": "Show Enterprise contact card", "type": "boolean", "default": true },
+    { "id": "enterpriseName", "label": "Enterprise card name", "type": "string", "default": "Enterprise" },
+    { "id": "enterprisePrice", "label": "Enterprise price line", "type": "string", "default": "Individuelles Angebot" },
+    {
+      "id": "enterpriseFeatures",
+      "label": "Enterprise features (rich text)",
+      "type": "richtext",
+      "default": "<ul><li>Ab 50 Lizenzen</li><li>SSO &amp; individueller Katalog</li><li>Für Betriebsräte, Bibliotheken &amp; Hochschulen</li><li>Persönlicher Account Manager</li></ul>"
+    },
+    { "id": "enterpriseCta", "label": "Enterprise CTA", "type": "string", "default": "Vertrieb kontaktieren" },
+    { "id": "enterpriseCtaHref", "label": "Enterprise CTA link", "type": "string", "default": "mailto:business@cafeyn.co" },
+    { "id": "componentId", "label": "Component Id", "type": "string", "default": "plaene" }
+  ]
+}

--- a/components/cafeyn-order-confirmation/componentStaticProps.js
+++ b/components/cafeyn-order-confirmation/componentStaticProps.js
@@ -1,0 +1,8 @@
+import { useComponentProps, getPropsFromPackageJson } from "@limio/sdk"
+import packageData from "./package.json"
+
+const defaultComponentProps = getPropsFromPackageJson(packageData)
+
+export function useStaticProps() {
+    return useComponentProps(defaultComponentProps)
+}

--- a/components/cafeyn-order-confirmation/index.css
+++ b/components/cafeyn-order-confirmation/index.css
@@ -1,0 +1,254 @@
+.cafeyn-oc {
+  --cafeyn-oil: #211712;
+  --cafeyn-cream: #FFFDF9;
+  --cafeyn-surface: #F2ECE2;
+  --cafeyn-bone: #DED0B9;
+  --cafeyn-caramel: #885F46;
+  --cafeyn-latte: #D2BD9F;
+  --cafeyn-muted: #5C4F45;
+  --cafeyn-white: #FFFFFF;
+  --cafeyn-line: #E7DFD2;
+  --cafeyn-font-serif: "Newsreader", Georgia, serif;
+  --cafeyn-font-sans: "Source Sans 3", "Source Sans Pro", -apple-system, sans-serif;
+  --cafeyn-radius-btn: 8px;
+  --cafeyn-radius-card: 16px;
+  --cafeyn-radius-pill: 9999px;
+  --cafeyn-shadow-rest: 0 1px 3px rgba(33, 23, 18, 0.06);
+  --cafeyn-shadow-lift: 0 12px 32px rgba(33, 23, 18, 0.12);
+  font-family: var(--cafeyn-font-sans);
+  color: var(--cafeyn-oil);
+  background: var(--cafeyn-cream);
+  display: block;
+  max-width: 44rem;
+  margin: 0 auto;
+  padding: 3.5rem 1.25rem 4rem;
+}
+
+.cafeyn-oc *,
+.cafeyn-oc *::before,
+.cafeyn-oc *::after {
+  box-sizing: border-box;
+}
+
+/* Hero */
+.cafeyn-oc__hero {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.cafeyn-oc__check {
+  display: inline-flex;
+  color: var(--cafeyn-caramel);
+  margin-bottom: 1rem;
+}
+
+.cafeyn-oc__check-ring {
+  stroke: var(--cafeyn-bone);
+}
+
+.cafeyn-oc__check-tick {
+  stroke: var(--cafeyn-caramel);
+  stroke-dasharray: 30;
+  stroke-dashoffset: 30;
+  animation: cafeyn-oc-tick 0.6s ease-out 0.2s forwards;
+}
+
+@keyframes cafeyn-oc-tick {
+  to { stroke-dashoffset: 0; }
+}
+
+.cafeyn-oc__eyebrow {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cafeyn-caramel);
+  margin-bottom: 0.75rem;
+}
+
+.cafeyn-oc__heading {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 2.25rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0 0 0.75rem;
+}
+
+.cafeyn-oc__sub {
+  color: var(--cafeyn-muted);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  margin: 0 auto;
+  max-width: 32rem;
+}
+
+/* Summary card */
+.cafeyn-oc__summary {
+  background: var(--cafeyn-white);
+  border: 1px solid var(--cafeyn-line);
+  border-radius: var(--cafeyn-radius-card);
+  box-shadow: var(--cafeyn-shadow-rest);
+  padding: 0.5rem 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.cafeyn-oc__summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--cafeyn-line);
+  font-size: 0.9375rem;
+}
+
+.cafeyn-oc__summary-row:last-child {
+  border-bottom: 0;
+}
+
+.cafeyn-oc__summary-label {
+  color: var(--cafeyn-muted);
+  flex-shrink: 0;
+}
+
+.cafeyn-oc__summary-value {
+  text-align: right;
+}
+
+.cafeyn-oc__summary-value code {
+  font-size: 0.8125rem;
+  background: var(--cafeyn-surface);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+/* Next steps */
+.cafeyn-oc__steps {
+  margin-bottom: 2rem;
+}
+
+.cafeyn-oc__steps-heading {
+  font-family: var(--cafeyn-font-serif);
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin: 0 0 1rem;
+  text-align: center;
+}
+
+.cafeyn-oc__grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.cafeyn-oc__item {
+  display: flex;
+  gap: 0.9rem;
+  background: var(--cafeyn-surface);
+  border-radius: var(--cafeyn-radius-card);
+  padding: 1rem 1.25rem;
+}
+
+.cafeyn-oc__icon {
+  flex-shrink: 0;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: var(--cafeyn-bone);
+  color: var(--cafeyn-oil);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cafeyn-oc__item-label {
+  font-weight: 600;
+  margin-bottom: 0.15rem;
+}
+
+.cafeyn-oc__item-desc {
+  color: var(--cafeyn-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+/* CTAs */
+.cafeyn-oc__actions {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.cafeyn-oc__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--cafeyn-radius-btn);
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+
+.cafeyn-oc__cta--primary {
+  background: var(--cafeyn-oil);
+  color: var(--cafeyn-white);
+}
+
+.cafeyn-oc__cta--primary:hover {
+  background: #3a2b22;
+}
+
+.cafeyn-oc__cta--ghost {
+  background: var(--cafeyn-white);
+  color: var(--cafeyn-oil);
+  border: 1px solid var(--cafeyn-oil);
+}
+
+.cafeyn-oc__cta--ghost:hover {
+  background: var(--cafeyn-surface);
+}
+
+/* Footer links */
+.cafeyn-oc__footer {
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--cafeyn-muted);
+}
+
+.cafeyn-oc__footer-link {
+  color: var(--cafeyn-caramel);
+  text-decoration: none;
+}
+
+.cafeyn-oc__footer-link:hover {
+  text-decoration: underline;
+}
+
+.cafeyn-oc__footer-sep {
+  margin: 0 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .cafeyn-oc {
+    padding: 2.5rem 1rem 3rem;
+  }
+
+  .cafeyn-oc__heading {
+    font-size: 1.75rem;
+  }
+
+  .cafeyn-oc__summary-row {
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .cafeyn-oc__summary-value {
+    text-align: left;
+  }
+}

--- a/components/cafeyn-order-confirmation/index.js
+++ b/components/cafeyn-order-confirmation/index.js
@@ -1,0 +1,248 @@
+import React from "react"
+import { ErrorBoundary, formatCurrency, useSubscriptions } from "@limio/sdk"
+import { useCompleteCheckoutSession, useLimioUserSubscriptionPaymentMethods } from "@limio/internal-checkout-sdk"
+import { useStaticProps } from "./componentStaticProps"
+import "./index.css"
+
+const Icon = ({ name }) => {
+    const common = { width: 20, height: 20, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: "1.75", strokeLinecap: "round", strokeLinejoin: "round" }
+    switch (name) {
+        case "sparkle":
+            return <svg {...common}><path d="M12 3v4M12 17v4M3 12h4M17 12h4M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M5.6 18.4l2.8-2.8M15.6 8.4l2.8-2.8" /></svg>
+        case "seat":
+            return <svg {...common}><circle cx="12" cy="7" r="3" /><path d="M5 21c0-4 3-7 7-7s7 3 7 7" /></svg>
+        case "book":
+            return <svg {...common}><path d="M4 5a2 2 0 0 1 2-2h12v18H6a2 2 0 0 1-2-2V5z" /><path d="M8 7h6M8 11h6" /></svg>
+        case "mail":
+            return <svg {...common}><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 7l9 6 9-6" /></svg>
+        case "podcast":
+            return <svg {...common}><circle cx="12" cy="12" r="2" /><path d="M9 12a3 3 0 0 1 6 0M6 12a6 6 0 0 1 12 0M12 14v8" /></svg>
+        default:
+            return <svg {...common}><circle cx="12" cy="12" r="9" /><path d="M9 12l2 2 5-5" /></svg>
+    }
+}
+
+const fillTemplate = (tpl, vars) => String(tpl || "").replace(/\{(\w+)\}/g, (_, k) => (vars[k] ?? ""))
+
+const formatAmount = (amount, currency) => {
+    if (amount == null) return ""
+    try {
+        return new Intl.NumberFormat("de-DE", { style: "currency", currency: currency || "EUR" }).format(Number(amount))
+    } catch {
+        try { return formatCurrency(amount, currency || "EUR") } catch { return `${amount} €` }
+    }
+}
+
+const formatDate = (d) => {
+    if (!d) return ""
+    try { return new Date(d).toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric" }) } catch { return String(d) }
+}
+
+// Walks the Limio payment-method object — which can come back under one of
+// several shapes depending on the gateway — and picks out a human brand
+// label + the last4 (ported from stripe-components/order-confirmation).
+const summariseCard = (pm) => {
+    if (!pm) return null
+    const data = pm.data || {}
+    const zuora = data.zuora?.result || data.zuora_stripe_card?.result || data.CreditCard || {}
+    const integration = data.integrationData?.self_service || {}
+    const stripeLike = pm.card || data.card || data.stripe?.card || {}
+
+    const last4 =
+        data.last4 ||
+        zuora.CreditCardMaskNumber?.slice(-4) ||
+        zuora.last4 ||
+        stripeLike.last4 ||
+        integration.last4 ||
+        pm.last4 ||
+        ""
+
+    const rawBrand =
+        zuora.CreditCardType ||
+        stripeLike.brand ||
+        stripeLike.network ||
+        integration.brand ||
+        data.CreditCardType ||
+        ""
+
+    const GATEWAY_TOKENS = /^(zuora|stripe|stripe_payment_element|stripe_card|paypal_wrapper)$/i
+    const brand = rawBrand && !GATEWAY_TOKENS.test(String(rawBrand)) ? rawBrand : null
+
+    if (!brand && !last4) return null
+    return { brand: brand || "Karte", last4: last4 || "" }
+}
+
+const CafeynOrderConfirmation = () => {
+    const props = useStaticProps() || {}
+    const {
+        eyebrow, heading, subheading,
+        planLabel, seatsLabel, addOnsLabel, nameLabel, emailLabel, referenceLabel,
+        paymentLabel, paymentEndingText, nextChargeLabel, nextChargeJoiner,
+        stepsHeading, steps = [],
+        primaryCta, primaryHref, secondaryCta, secondaryHref,
+        footerLinks = [],
+        componentId = "cafeyn-order-confirmation",
+    } = props
+
+    // Read the just-completed order from the checkout session (NOT useUser,
+    // which is the auth account — could differ from the checkout customer).
+    const { useCheckoutSelector } = useCompleteCheckoutSession?.() || {}
+    const order = useCheckoutSelector?.((s) => s?.order) || {}
+    const {
+        customerDetails = {},
+        orderItems = [],
+        order_reference,
+        sub_reference,
+        subscriptionReference,
+    } = order
+
+    const firstName = customerDetails.firstName || ""
+    const lastName = customerDetails.lastName || ""
+    const email = customerDetails.email || ""
+
+    const baseItem = orderItems.find((item) => item?.offer) || {}
+    const planName = baseItem.offer?.data?.attributes?.display_name__limio || ""
+    const seatCount = Number(baseItem.quantity) > 1 ? Number(baseItem.quantity) : null
+    const addOnNames = orderItems
+        .flatMap((item) => [
+            ...(Array.isArray(item.crossSell) ? item.crossSell : []),
+            ...(item.type === "add_on" ? [item] : []),
+        ])
+        .map((a) => a?.offer?.data?.attributes?.display_name__limio || a?.data?.attributes?.display_name__limio)
+        .filter(Boolean)
+
+    const { subscriptions = [] } = useSubscriptions() || {}
+    const subRef = sub_reference || subscriptionReference
+    const sub = (subRef && subscriptions.find((s) => s.name === subRef || s.reference === subRef))
+        || subscriptions[0]
+
+    const subName = planName || sub?.productName || sub?.offer?.name || sub?.name || ""
+    const nextDate = sub?.nextPaymentDate ?? sub?.schedule?.find?.((s) => s.type === "payment")?.date
+    const nextAmount = sub?.nextPaymentAmount ?? sub?.schedule?.find?.((s) => s.type === "payment")?.amount
+    const currency = sub?.currency || order.currency || "EUR"
+    const reference = order_reference || subRef || sub?.id
+
+    const subId = sub?.id
+    const { payment_methods = [], paymentMethods = [] } =
+        useLimioUserSubscriptionPaymentMethods?.(subId) || {}
+    const paymentList = payment_methods.length ? payment_methods : paymentMethods
+    const defaultPayment = paymentList.find((p) => p.default || p.isDefault) || paymentList[0]
+    const cardSummary = summariseCard(defaultPayment) || summariseCard(sub?.paymentMethod)
+
+    const rows = [
+        subName && { label: planLabel, value: <span>{subName}</span> },
+        seatCount && { label: seatsLabel, value: <span>{seatCount}</span> },
+        addOnNames.length > 0 && { label: addOnsLabel, value: <span>{addOnNames.join(", ")}</span> },
+        (firstName || lastName) && { label: nameLabel, value: <span>{`${firstName} ${lastName}`.trim()}</span> },
+        email && { label: emailLabel, value: <span>{email}</span> },
+        reference && { label: referenceLabel, value: <code>{reference}</code> },
+        cardSummary && {
+            label: paymentLabel,
+            value: (
+                <span>
+                    {cardSummary.brand}
+                    {cardSummary.last4 && <> {paymentEndingText} <strong>{cardSummary.last4}</strong></>}
+                </span>
+            ),
+        },
+        nextDate && {
+            label: nextChargeLabel,
+            value: (
+                <span>
+                    <strong>{formatAmount(nextAmount, currency)}</strong> {nextChargeJoiner} <strong>{formatDate(nextDate)}</strong>
+                </span>
+            ),
+        },
+    ].filter(Boolean)
+
+    return (
+        <section id={componentId} className="cafeyn-oc">
+            <header className="cafeyn-oc__hero">
+                <div className="cafeyn-oc__check" aria-hidden="true">
+                    <svg viewBox="0 0 40 40" width="44" height="44">
+                        <circle cx="20" cy="20" r="18" fill="none" strokeWidth="2" className="cafeyn-oc__check-ring" />
+                        <path d="M12 20.5L18 26 29 14" fill="none" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" className="cafeyn-oc__check-tick" />
+                    </svg>
+                </div>
+                {eyebrow && <div className="cafeyn-oc__eyebrow">{eyebrow}</div>}
+                {heading && <h1 className="cafeyn-oc__heading">{fillTemplate(heading, { firstName: firstName || "willkommen" })}</h1>}
+                {subheading && <p className="cafeyn-oc__sub">{subheading}</p>}
+            </header>
+
+            {rows.length > 0 && (
+                <div className="cafeyn-oc__summary">
+                    {rows.map((row, i) => (
+                        <div className="cafeyn-oc__summary-row" key={i}>
+                            <span className="cafeyn-oc__summary-label">{row.label}</span>
+                            <span className="cafeyn-oc__summary-value">{row.value}</span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {steps.length > 0 && (
+                <div className="cafeyn-oc__steps">
+                    {stepsHeading && <h2 className="cafeyn-oc__steps-heading">{stepsHeading}</h2>}
+                    <ul className="cafeyn-oc__grid">
+                        {steps.map((step) => (
+                            <li key={step.id || step.label} className="cafeyn-oc__item">
+                                <span className="cafeyn-oc__icon"><Icon name={step.icon} /></span>
+                                <div className="cafeyn-oc__item-body">
+                                    <div className="cafeyn-oc__item-label">{step.label}</div>
+                                    {step.description && <div className="cafeyn-oc__item-desc">{step.description}</div>}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
+            <div className="cafeyn-oc__actions">
+                {primaryCta && (
+                    <a href={primaryHref || "/ca-account"} className="cafeyn-oc__cta cafeyn-oc__cta--primary">
+                        {primaryCta}
+                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                            <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                    </a>
+                )}
+                {secondaryCta && (
+                    <a href={secondaryHref || "#"} className="cafeyn-oc__cta cafeyn-oc__cta--ghost">{secondaryCta}</a>
+                )}
+            </div>
+
+            {footerLinks.length > 0 && (
+                <div className="cafeyn-oc__footer">
+                    {footerLinks.map((link, i) => (
+                        <React.Fragment key={link.id || i}>
+                            {i > 0 && <span className="cafeyn-oc__footer-sep" aria-hidden="true">·</span>}
+                            <a href={link.href || "#"} className="cafeyn-oc__footer-link">{link.label}</a>
+                        </React.Fragment>
+                    ))}
+                </div>
+            )}
+        </section>
+    )
+}
+
+CafeynOrderConfirmation.Skeleton = () => (
+    <div className="cafeyn-oc">
+        <div className="cafeyn-oc__summary" style={{ minHeight: "12rem" }} />
+    </div>
+)
+
+CafeynOrderConfirmation.Error = () => (
+    <div className="cafeyn-oc">
+        <p style={{ textAlign: "center" }}>
+            Ihre Bestellung war erfolgreich — die Details können gerade nicht angezeigt werden. Sie erhalten in Kürze eine Bestätigung per E-Mail.
+        </p>
+    </div>
+)
+
+const Wrapped = () => (
+    <ErrorBoundary fallback={<CafeynOrderConfirmation.Error />}>
+        <CafeynOrderConfirmation />
+    </ErrorBoundary>
+)
+
+export default Wrapped

--- a/components/cafeyn-order-confirmation/package.json
+++ b/components/cafeyn-order-confirmation/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@limio/cafeyn-order-confirmation",
+  "version": "1.0.0",
+  "description": "Cafeyn for Business order confirmation — success hero, order summary (plan, seats, add-ons, payment, next charge), invite-your-team next steps. Ported from stripe-components/order-confirmation, Cafeyn design language, German copy.",
+  "main": "./index.js",
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    { "id": "eyebrow", "label": "Eyebrow", "type": "string", "default": "Bestellung bestätigt" },
+    { "id": "heading", "label": "Heading (supports {firstName})", "type": "string", "default": "Willkommen bei Cafeyn for Business, {firstName}." },
+    { "id": "subheading", "label": "Subheading", "type": "string", "default": "Ihr Team hat jetzt Zugriff auf über 2.500 Titel. Eine Bestellbestätigung ist unterwegs an Ihre E-Mail-Adresse." },
+    { "id": "planLabel", "label": "Row label: plan", "type": "string", "default": "Plan" },
+    { "id": "seatsLabel", "label": "Row label: seats", "type": "string", "default": "Lizenzen" },
+    { "id": "addOnsLabel", "label": "Row label: add-ons", "type": "string", "default": "Add-ons" },
+    { "id": "nameLabel", "label": "Row label: name", "type": "string", "default": "Name" },
+    { "id": "emailLabel", "label": "Row label: receipt email", "type": "string", "default": "Beleg an" },
+    { "id": "referenceLabel", "label": "Row label: reference", "type": "string", "default": "Referenz" },
+    { "id": "paymentLabel", "label": "Row label: payment", "type": "string", "default": "Zahlungsmittel" },
+    { "id": "paymentEndingText", "label": "Card 'ending in' text", "type": "string", "default": "endet auf" },
+    { "id": "nextChargeLabel", "label": "Row label: next charge", "type": "string", "default": "Nächste Abbuchung" },
+    { "id": "nextChargeJoiner", "label": "Word between amount and date", "type": "string", "default": "am" },
+    { "id": "stepsHeading", "label": "Next steps heading", "type": "string", "default": "So starten Sie mit Ihrem Team" },
+    {
+      "id": "steps",
+      "label": "Next steps",
+      "type": "list",
+      "fields": {
+        "id": { "id": "id", "label": "ID", "type": "string" },
+        "label": { "id": "label", "label": "Label", "type": "string" },
+        "description": { "id": "description", "label": "Description", "type": "string" },
+        "icon": { "id": "icon", "label": "Icon key", "type": "string" }
+      },
+      "default": [
+        { "id": "invite", "label": "Team einladen", "description": "Fügen Sie Ihre Mitarbeitenden mit wenigen Klicks hinzu — jede Lizenz ist sofort aktiv.", "icon": "seat" },
+        { "id": "apps", "label": "Apps installieren", "description": "Cafeyn für iOS, Android und Web — offline lesen inklusive.", "icon": "book" },
+        { "id": "manage", "label": "Abo jederzeit anpassen", "description": "Lizenzen, Plan und Add-ons verwalten Sie im Self-Service-Bereich.", "icon": "sparkle" }
+      ]
+    },
+    { "id": "primaryCta", "label": "Primary CTA", "type": "string", "default": "Zum Kundenkonto" },
+    { "id": "primaryHref", "label": "Primary link", "type": "string", "default": "/ca-account" },
+    { "id": "secondaryCta", "label": "Secondary CTA", "type": "string", "default": "Weitere Titel entdecken" },
+    { "id": "secondaryHref", "label": "Secondary link", "type": "string", "default": "https://www.cafeyn.co/de" },
+    {
+      "id": "footerLinks",
+      "label": "Footer helper links",
+      "type": "list",
+      "fields": {
+        "id": { "id": "id", "label": "ID", "type": "string" },
+        "label": { "id": "label", "label": "Label", "type": "string" },
+        "href": { "id": "href", "label": "Link", "type": "string" }
+      },
+      "default": [
+        { "id": "faq", "label": "Häufige Fragen", "href": "/ca-pricing#faq" },
+        { "id": "contact", "label": "Support kontaktieren", "href": "mailto:business@cafeyn.co" }
+      ]
+    },
+    { "id": "componentId", "label": "Component Id", "type": "string", "default": "cafeyn-order-confirmation" }
+  ]
+}

--- a/references/CAFEYN-DESIGN-LANGUAGE.md
+++ b/references/CAFEYN-DESIGN-LANGUAGE.md
@@ -1,0 +1,205 @@
+# Cafeyn Design Language
+
+The primitives and rules behind the Cafeyn B2B demo (`cafeyn-*` components +
+`ca-*` pages on saas-dev). Modeled on the limio.com design-language method
+(`limio-custom-components/references/DESIGN-LANGUAGE.md`) — same structure,
+Cafeyn values. Use this to build anything that must feel native to Cafeyn's
+September-2024 identity ("Read as you like" / "Lisez comme vous aimez"):
+warm, neutral, high-contrast, editorial — brown ink on cream, a "café crème"
+identity. Not coral-red LeKiosk, not tech-blue SaaS.
+
+**Verified live** against cafeyn.co on 2026-07-23 (computed styles read from
+the production site) — these are real values, not approximations, except
+where marked.
+
+---
+
+## 1. Tokens
+
+### Color
+
+| Token | Value | Use |
+|---|---|---|
+| `--cafeyn-oil` | `#211712` | Espresso-brown ink: headings, body text, logo, **primary CTA background**, dark bands |
+| `--cafeyn-cream` | `#FFFDF9` | Page background (warm off-white — lighter than you'd guess) |
+| `--cafeyn-surface` | `#F2ECE2` | Alternate section bands, card fills, table stripes |
+| `--cafeyn-bone` | `#DED0B9` | Signature latte tone: badges, highlight fills, decorative bands |
+| `--cafeyn-caramel` | `#885F46` | Sparing accent: kickers, links, icons, active states |
+| `--cafeyn-latte` | `#D2BD9F` | Secondary latte: borders on tinted surfaces, chart fills (sparing) |
+| `--cafeyn-muted` | `#5C4F45` | Secondary copy, captions (approximation — derived, on-brand) |
+| `--cafeyn-white` | `#FFFFFF` | Cards on cream, text on Oil |
+| `--cafeyn-line` | `#E7DFD2` | Hairline borders on cream/white (approximation) |
+
+- Dark bands are solid Oil `#211712` with cream/white text — no gradients
+  anywhere in the 2024 identity.
+- Tints of Bone (`rgba(222, 208, 185, 0.25–0.5)`) for hover washes and
+  highlighted rows. Never grey tints on this site — warmth always.
+- Let magazine covers provide the color; the chrome stays brown/cream.
+
+### Typography
+
+Two families (both Google Fonts):
+
+- **Newsreader** (serif) — headlines only. Cafeyn's live site uses
+  Newsreader for every `h1`–`h3`. Weights 400–600, optical sizing on.
+- **Source Sans 3** (sans) — body, UI, buttons, labels. Weight 400/600.
+  (Cafeyn also loads GT Walsheim for its wordmark; it's commercial — the
+  wordmark ships as an image instead.)
+
+| Role | Spec |
+|---|---|
+| h1 (hero) | Newsreader, 3.5rem / 1.1, w500, `oil` (live site: 58px) |
+| h2 (section) | Newsreader, 2.5rem / 1.15, w500, `oil` |
+| h3 (card title) | Newsreader, 1.5rem / 1.25, w500, `oil` |
+| Kicker | Source Sans 3, 0.875rem, w600, uppercase, 0.08em tracking, `caramel` |
+| Body | Source Sans 3, 1.0625rem / 1.6, w400, `oil` |
+| Body muted | Source Sans 3, 1rem / 1.6, w400, `muted` |
+| UI/buttons | Source Sans 3, 1rem, w600 |
+| Price figure | Newsreader, 2.25rem, w500, `oil` |
+| Fine print | Source Sans 3, 0.8125rem / 1.5, w400, `muted` |
+
+German copy conventions (this demo is 100 % German): formal *Sie*; prices
+`12 €`, `12,99 €` (comma decimals, non-breaking space before €);
+`pro Nutzer/Monat`; dates `23.07.2026`.
+
+### Spacing & layout
+
+- **Container**: width `90%`, `max-width: 72rem`, centered.
+- **Section padding**: `4.5rem 0` desktop, `2.5rem 0` at ≤ 767 px.
+- **Gap scale**: 0.5 / 0.75 / 1 / 1.5 / 2 / 3 / 4.5 rem.
+- **Breakpoints**: 991 / 767 / 479.
+
+### Radii & elevation (verified live)
+
+| Element | Radius |
+|---|---|
+| Buttons, inputs | `8px` |
+| Cards, panels, cover thumbnails | `16px` |
+| Chips, avatar-ish elements, toggle track | `9999px` (pill) |
+| Small inline elements (tags) | `4px` |
+
+Shadows — soft and warm-neutral, used sparingly:
+- Resting card: `0 1px 3px rgba(33, 23, 18, 0.06)`
+- Lifted card / featured plan: `0 12px 32px rgba(33, 23, 18, 0.12)`
+- Cover thumbnail: `0 4px 12px rgba(33, 23, 18, 0.15)`
+
+### The shared token block
+
+Every `cafeyn-*` component copies this verbatim at the top of its
+`index.css` (the `limio-custom-components` convention — components are
+self-contained, tokens repeated per component, all classes namespaced):
+
+```css
+.cafeyn-<component> {
+  --cafeyn-oil: #211712;
+  --cafeyn-cream: #FFFDF9;
+  --cafeyn-surface: #F2ECE2;
+  --cafeyn-bone: #DED0B9;
+  --cafeyn-caramel: #885F46;
+  --cafeyn-latte: #D2BD9F;
+  --cafeyn-muted: #5C4F45;
+  --cafeyn-white: #FFFFFF;
+  --cafeyn-line: #E7DFD2;
+  --cafeyn-font-serif: "Newsreader", Georgia, serif;
+  --cafeyn-font-sans: "Source Sans 3", "Source Sans Pro", -apple-system, sans-serif;
+  --cafeyn-radius-btn: 8px;
+  --cafeyn-radius-card: 16px;
+  --cafeyn-radius-pill: 9999px;
+  --cafeyn-shadow-rest: 0 1px 3px rgba(33, 23, 18, 0.06);
+  --cafeyn-shadow-lift: 0 12px 32px rgba(33, 23, 18, 0.12);
+  font-family: var(--cafeyn-font-sans);
+  color: var(--cafeyn-oil);
+}
+```
+
+Fonts are loaded once per page via the page's `pageStyle`
+(`@import url("https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400..600&family=Source+Sans+3:wght@400;600&display=swap");`)
+— components reference the families but don't import them.
+
+---
+
+## 2. Primitives
+
+### Buttons
+`padding: 0.75rem 1.5rem`, radius `8px`, Source Sans 3 w600 1rem.
+- **Primary**: Oil bg, white text; hover `#3A2B22` (Oil lifted 10 %).
+- **Secondary**: white bg, 1px `oil` border, oil text; hover `surface` bg.
+- **Ghost/link**: no bg, `caramel` text, underline on hover.
+- On dark (Oil) bands: white bg + oil text, or white outline.
+
+### Cards
+White bg on cream pages, 1px `--cafeyn-line` border, 16px radius, resting
+shadow. **Featured plan** ("Beliebteste Wahl"): 2px Oil border + lifted
+shadow + a Bone pill badge top-center; never a color flip.
+
+### Badges & chips
+Pill radius, Bone bg, Oil text, 0.8125rem w600 (`Beliebteste Wahl`,
+`-17 % jährlich`). Accent chips (promo applied): caramel bg, white text.
+
+### Check rows
+Caramel check glyph (inline SVG) in a Bone-tinted disc (1.25rem circle,
+`rgba(222,208,185,0.5)`), 0.75rem gap to the label, Source Sans 3.
+
+### Quantity stepper (the per-seat control)
+Pill-shaped track (`9999px`, surface bg, 1px line border) with − / + round
+buttons (Oil on white) and the seat count in Newsreader w500 between them.
+Label above: `Anzahl Lizenzen` (0.875rem, muted).
+
+### Cover imagery
+Magazine covers are the identity's color source: 2:3 ratio thumbnails,
+4–8px radius, cover shadow, slight overlap or marquee strips. Lead with
+German titles (Der Spiegel, Stern, Focus, 11FREUNDE), then Le Monde,
+The Independent.
+
+### Icons
+Inline SVG, 1.5px stroke, `currentColor` (inherits oil/caramel). No icon
+fonts, no emoji in UI.
+
+---
+
+## 3. Section patterns
+
+| Band | Component | Notes |
+|---|---|---|
+| Nav | `nav-header-tailwind` (reused, themed via props) | Cafeyn logo (oil on cream), links oil |
+| Hero | `cafeyn-hero` | Cream bg, Newsreader headline, subcopy, primary CTA, cover collage right |
+| Pricing cards | `cafeyn-offers` | 3 cards (Team / Business / Enterprise-contact), term toggle, seat stepper, featured = Business |
+| Covers band | `cafeyn-covers-band` (optional) | Marquee strip of covers on surface band |
+| Comparison | `comparison-table` (reused) | Surface band, oil header row |
+| FAQ | `faq-accordion` (reused) | White cards, 16px radius |
+| CTA closer | `cta-banner` (reused) | Solid Oil band, white text, white button |
+| Footer | `footer-tailwind` (reused, themed) | Oil bg, cream text |
+| Order confirmation | `cafeyn-order-confirmation` | Cream page, white summary card, next-steps checklist |
+
+Band rhythm: cream → white cards → surface band → cream → Oil closer.
+Never two tinted bands adjacent.
+
+## 4. Page recipes
+
+- **`/ca-pricing`** (the showcase): nav → `cafeyn-hero` → `cafeyn-offers`
+  → `cafeyn-covers-band` → `comparison-table` → `faq-accordion` →
+  `cta-banner` (Oil) → footer.
+- **`/ca-checkout`**: Limio modular checkout themed via `pageStyle`
+  (fonts + colors only; structure is Limio's). B2B fields: Firmenname,
+  USt-IdNr., Branche. Cross-sell add-ons + Team→Business upsell in cart.
+- **`/ca-confirm`**: nav → `cafeyn-order-confirmation` → footer.
+- **`/ca-account` + journeys** (`/ca-invoices`, `/ca-cancel`, …): Leemeeo
+  page clones restyled via `pageStyle` — components unchanged, German
+  labels via props, Cafeyn tokens via CSS.
+
+## 5. Rules of thumb
+
+1. **One accent per element.** Caramel *or* Bone, never both on the same
+   element. If everything is warm, nothing is.
+2. **Oil is the only "brand color" a CTA needs.** Resist colored buttons.
+3. **Serif for meaning, sans for mechanics.** Plan names, prices, and
+   headlines in Newsreader; everything interactive in Source Sans 3.
+4. **Buttons are 8px, cards are 16px, chips are pills.** Don't invent radii.
+5. **Cream ≠ white.** Page background is `#FFFDF9`; cards sit on it in pure
+   white; `#F2ECE2` marks a section change. Three layers, always in that
+   order.
+6. **Covers carry the color.** If a band looks flat, add covers — not color.
+7. **German first.** Default prop values are the final German copy, not
+   English placeholders (formal *Sie*, `12,99 €`, `pro Nutzer/Monat`).
+8. **Page-level styling lives in `pageStyle`**, component CSS is scoped to
+   the component's own subtree.


### PR DESCRIPTION
## Summary
- `cafeyn-hero`, `cafeyn-offers`, `cafeyn-order-confirmation`, `cafeyn-covers-band` — Cafeyn-branded (verified live against cafeyn.co), German default copy throughout
- `references/CAFEYN-DESIGN-LANGUAGE.md` — tokens/primitives/page recipes; every cafeyn-* component embeds the shared token block
- Storybook stories for all four (verified rendering locally), playground internal-checkout-sdk mock extended with `useCompleteCheckoutSession`

## Why merge matters now
The Cafeyn demo pages on saas-dev (`/ca-pricing`, `/ca-confirm`) reference these components — they only sync into the tenant via the saas-dev → CodeCommit mirror, so the pages can't build until this lands.

## Demo context
Cafeyn B2B demo (Juliette & Alexandre, eval vs Chargebee) per CAFEYN-DEMO-PLAN.md — offer catalog + CAFEYN20 promo already created on saas-dev via API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)