### PR TITLE
fix: drop external xss dep in cafeyn-hero/cafeyn-offers — unblocks shop build

### DIFF
--- a/components/cafeyn-hero/index.js
+++ b/components/cafeyn-hero/index.js
@@ -1,10 +1,9 @@
 import React from "react"
-import { ErrorBoundary } from "@limio/sdk"
-import xss from "xss"
+import { ErrorBoundary, sanitiseHTML } from "@limio/sdk"
 import { useStaticProps } from "./componentStaticProps"
 import "./index.css"
 
-const sanitize = (str) => xss(str || "")
+const sanitize = (str) => sanitiseHTML(str || "")
 
 // Styled placeholder palette for covers without an image — warm editorial
 // tones so the collage carries color the way real covers would.

--- a/components/cafeyn-hero/package.json
+++ b/components/cafeyn-hero/package.json
@@ -1,11 +1,9 @@
 {
   "name": "@limio/cafeyn-hero",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cafeyn for Business pricing-page hero — Newsreader headline, subcopy, CTAs, magazine-cover collage. German copy by default.",
   "main": "./index.js",
-  "dependencies": {
-    "xss": "^1.0.8"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "react": "*"
   },

--- a/components/cafeyn-offers/index.js
+++ b/components/cafeyn-offers/index.js
@@ -1,11 +1,10 @@
 import React, { useMemo, useState } from "react"
-import { ErrorBoundary, useBasket, useCampaign, useLimioContext } from "@limio/sdk"
+import { ErrorBoundary, useBasket, useCampaign, useLimioContext, sanitiseHTML } from "@limio/sdk"
 import { groupBy, prop } from "ramda"
-import xss from "xss"
 import { useStaticProps } from "./componentStaticProps"
 import "./index.css"
 
-const sanitize = (str) => xss(str || "")
+const sanitize = (str) => sanitiseHTML(str || "")
 
 const fillTemplate = (tpl, vars) => String(tpl || "").replace(/\{(\w+)\}/g, (_, k) => (vars[k] ?? ""))
 

--- a/components/cafeyn-offers/package.json
+++ b/components/cafeyn-offers/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@limio/cafeyn-offers",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cafeyn B2B pricing cards — monthly/annual toggle, per-seat quantity stepper with live totals, best-value badge, static Enterprise contact card. German copy by default.",
   "main": "./index.js",
   "dependencies": {
-    "ramda": "^0.28.0",
-    "xss": "^1.0.8"
+    "ramda": "^0.28.0"
   },
   "peerDependencies": {
     "react": "*"


### PR DESCRIPTION
## Problem

The v117 shop build can no longer resolve the `xss` npm package when bundling `cafeyn-hero` and `cafeyn-offers`:

```
Error: Can't resolve 'xss' in '.../assets/cafeyn-hero_.../orig'
Error: Can't resolve 'xss' in '.../assets/cafeyn-offers_.../orig'
```

This **fails the entire CA Pricing shop build** (`build-saas-dev-shop:953a4a8c…` → FAILED), which in turn blocks publishing the Cafeyn B2B offers (e.g. Team Annual is currently unpublished, blocking the upgrade flow).

Same class of v117 regression as the FontAwesome-pro / `@limio/ui-form` / MUI breakages fixed in #75 / #76 / #77 — libraries the v117 build no longer resolves for components.

## Fix

Swap `import xss from "xss"` → the SDK's own `sanitiseHTML` (already a sibling import from `@limio/sdk`, and guaranteed present in the shop build), and drop `xss` from `dependencies`.

- `cafeyn-hero`: `sanitize(str)` now uses `sanitiseHTML`; deps `{}`.
- `cafeyn-offers`: same; deps keep only `ramda`.
- Both bumped `1.0.0 → 1.0.1`.

Same sanitisation behaviour (still sanitises rich-text before `dangerouslySetInnerHTML`), no external dep to externalise.

## Verify after merge
`limio publish "CA Pricing"` should now build clean and publish the Cafeyn B2B offers (Business + Team Annual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)