### PR TITLE
feat(components): add add-customer-details-to-order (quote-preview support)

### DIFF
--- a/components/add-customer-details-to-order/index.tsx
+++ b/components/add-customer-details-to-order/index.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+import { useBasket, captureException } from "@limio/sdk";
+import { useSelector } from "@limio/shop-redux";
+
+// Known customerDetails fields - these will be routed to customerDetails
+// All other fields will automatically go to customFields
+const CUSTOMER_DETAILS_FIELDS = [
+  "firstName",
+  "lastName",
+  "email",
+  "phone",
+  "companyName",
+] as const;
+
+type CustomerDetailField = (typeof CUSTOMER_DETAILS_FIELDS)[number];
+
+type FieldMapping = {
+  targetField: string;
+  queryParamName: string;
+};
+
+type Props = {
+  fieldMappings: FieldMapping[];
+};
+
+function AddCustomerDetailsToOrder({ fieldMappings }: Props): null {
+  const basket = useBasket();
+  const { updateBasketDetails, updateCustomField } = basket;
+  const basketId = useSelector((state: any) => state.id);
+
+  React.useEffect(() => {
+    if (!basketId) {
+      return;
+    }
+
+    const updateFields = async () => {
+      const urlParams = new URLSearchParams(window.location.search);
+
+      const customerDetailsToUpdate: Record<string, string> = {};
+      const customFieldsToUpdate: Record<string, any> = {};
+      const paramsToRemove: string[] = [];
+
+      fieldMappings.forEach(({ targetField, queryParamName }) => {
+        const value = urlParams.get(queryParamName);
+        if (value) {
+          if (
+            CUSTOMER_DETAILS_FIELDS.includes(targetField as CustomerDetailField)
+          ) {
+            customerDetailsToUpdate[targetField] = value;
+          } else {
+            customFieldsToUpdate[targetField] = value;
+          }
+
+          paramsToRemove.push(queryParamName);
+        }
+      });
+
+      if (
+        Object.keys(customerDetailsToUpdate).length === 0 &&
+        Object.keys(customFieldsToUpdate).length === 0
+      ) {
+        return;
+      }
+
+      try {
+        const updatePayload: any = {
+          data: {
+            order: {},
+          },
+        };
+
+        if (Object.keys(customerDetailsToUpdate).length > 0) {
+          updatePayload.data.order.customerDetails = customerDetailsToUpdate;
+        }
+
+        if (Object.keys(customFieldsToUpdate).length > 0) {
+          updatePayload.data.order.customFields = customFieldsToUpdate;
+        }
+
+        await updateBasketDetails(updatePayload);
+
+        // Update form inputs directly so FormLite's storeRef and FormData both
+        // pick up the values 
+        Object.entries(customerDetailsToUpdate).forEach(([field, value]) => {
+          const el = window.document.querySelector<HTMLInputElement>(
+            `[name="customerDetails.${field}"]`,
+          );
+          if (el) {
+            el.value = value;
+            el.dispatchEvent(new Event("change", { bubbles: true }));
+          }
+        });
+
+        // customFields are not form inputs — update via Redux only
+        Object.entries(customFieldsToUpdate).forEach(([key, value]) => {
+          updateCustomField(key, value);
+        });
+
+        paramsToRemove.forEach((param) => urlParams.delete(param));
+
+        const newUrl = urlParams.toString()
+          ? `${window.location.pathname}?${urlParams.toString()}${window.location.hash}`
+          : `${window.location.pathname}${window.location.hash}`;
+
+        window.history.replaceState({}, "", newUrl);
+      } catch (err) {
+        captureException(err);
+      }
+    };
+
+    updateFields();
+  }, [basketId, fieldMappings, updateBasketDetails, updateCustomField]);
+
+  return null;
+}
+
+export default AddCustomerDetailsToOrder;
+  

--- a/components/add-customer-details-to-order/package.json
+++ b/components/add-customer-details-to-order/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@limio/component-add-customer-details-to-order",
+  "version": "1.0.0",
+  "description": "A component to update customer details and custom fields on the order from query parameters. Automatically routes fields to customerDetails or customFields based on field name.",
+  "main": "./index.tsx",
+  "isCustomSubcomponent": true,
+  "scripts": {
+    "build": "yarn component:webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "react": "*"
+  },
+  "limioProps": [
+    {
+      "id": "fieldMappings",
+      "label": "Field Mappings: Maps URL query parameters to order fields. Standard customer fields (firstName, lastName, email, phone, companyName) go to customerDetails. All other fields go to customFields.",
+      "type": "list",
+      "fields": {
+        "targetField": {
+          "id": "targetField",
+          "label": "Target Field",
+          "type": "string",
+          "placeholder": "e.g., email, entityType, incorporationDate",
+          "description": "Field name to update. Standard fields (firstName, lastName, email, phone, companyName) go to customerDetails. All others go to customFields."
+        },
+        "queryParamName": {
+          "id": "queryParamName",
+          "label": "Query Parameter Name",
+          "type": "string",
+          "placeholder": "e.g., email, entity_type",
+          "description": "URL query parameter name to read the value from"
+        }
+      },
+      "default": [
+        {
+          "targetField": "firstName",
+          "queryParamName": "first_name"
+        },
+        {
+          "targetField": "lastName",
+          "queryParamName": "last_name"
+        },
+        {
+          "targetField": "email",
+          "queryParamName": "email"
+        },
+        {
+          "targetField": "phone",
+          "queryParamName": "phone"
+        },
+        {
+          "targetField": "companyName",
+          "queryParamName": "company_name"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What
Imports `add-customer-details-to-order` from `innovate42/limio-sprint-chat-components` (`sprint-chat`) into this repo.

## Why
Needed for the Amazing Life **Qualified Quote** flow. The chat agent builds a link to a read-only quote-preview checkout (`/al-quote-preview`) carrying the details it collected (name, email, phone, church). This component reads those query params and attaches them to the order/basket (`customerDetails` + `customFields`), so:
- the quote-preview page can display the collected details, and
- the abandoned-cart → Salesforce-lead automation has the contact info.

## Notes
- No-render subcomponent (`isCustomSubcomponent`, `.tsx`, `@limio/shop-redux`) — same shape as existing `saved-payment-checkout` / `block-invalid`.
- Standard fields (firstName, lastName, email, phone, companyName) → `customerDetails`; all others → `customFields`. Strips params from the URL after applying.
- Package `name` re-scoped to `@limio/component-add-customer-details-to-order` to match repo convention; code otherwise imported faithfully.
- Deploy to the tenant happens via the component build after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)